### PR TITLE
Let StreamMonitoredSubprocessCall wait on child process

### DIFF
--- a/fuzzinator/call/stream_monitored_subprocess_call.py
+++ b/fuzzinator/call/stream_monitored_subprocess_call.py
@@ -83,6 +83,7 @@ class StreamMonitoredSubprocessCall(object):
 
         try:
             os.kill(self.proc.pid, signal.SIGKILL)
+            self.proc.wait()
         except:
             pass
 


### PR DESCRIPTION
If child is not waited on, its returncode stays None.