### PR TITLE
Enable limiting the fuzz session to a given number of cycles

### DIFF
--- a/fuzzinator/controller.py
+++ b/fuzzinator/controller.py
@@ -156,12 +156,25 @@ class Controller(object):
         self._issue_queue = Queue()
         self._lock = Lock()
 
-    def run(self):
-        """Start the fuzz session."""
+    def run(self, *, max_cycles=None):
+        """
+        Start the fuzz session.
+
+        :param int max_cycles: maximum number to iterate through the fuzz jobs
+            defined in the configuration (defaults to ``inf``).
+        """
+        max_cycles = max_cycles if max_cycles is not None else float('inf')
+        cycle = 0
         running_jobs = dict()
         fuzz_idx = 0
         try:
             while True:
+                if fuzz_idx == 0:
+                    cycle += 1
+                if cycle > max_cycles or (not self.fuzzers and max_cycles != float('inf')):
+                    self._wait_for_load(self.capacity, running_jobs)
+                    break
+
                 next_job = None
                 if not self._issue_queue.empty():
 

--- a/fuzzinator/ui/cli/cli.py
+++ b/fuzzinator/ui/cli/cli.py
@@ -18,6 +18,7 @@ from .cli_listener import CliListener
 
 def execute(args=None, parser=None):
     parser = build_parser(parent=parser)
+    parser.add_argument('--max-cycles', metavar='N', default=None, type=int, help='limit number of fuzz job cycles to %(metavar)s (default is no limit)')
     arguments = parser.parse_args(args)
 
     logger = logging.getLogger('fuzzinator')
@@ -31,6 +32,6 @@ def execute(args=None, parser=None):
     controller.listener = CliListener()
 
     try:
-        controller.run()
+        controller.run(max_cycles=arguments.max_cycles)
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
If every fuzz job that is defined in the configuration gets
executed once, that counts as one cycle. Controller.run API got
extended with a parameter that can be used to specify a limit for
the cycles, and the line-based UI also got extended with an
appropriate command line argument. (The TUI did not get the option
as it makes no sense there.)