### PR TITLE
Add python 3.6 support to testing infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
       env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
 sudo: false
 
 # TODO: start mongodb once more complex tests are implemented

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,10 @@ environment:
   matrix:
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
 
 install: "%PYTHON%\\python.exe -m pip install tox"
 build: off

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-# default environment list: ``py34`` for python 3.4 and ``py35`` for python 3.5
-# (the ``py`` environment, which does not force a given version but runs
-# whatever interpreter was used for invoking tox, is not included; it can be
-# triggered explicitly, e.g., via ``tox -e py``)
-envlist = py34, py35
+# default environment list: ``py34``, ``py35``, and ``py36`` for python 3.4,
+# 3.5, and 3.6 (the ``py`` environment, which does not force a given version but
+# runs whatever interpreter was used for invoking tox, is not included; it can
+# be triggered explicitly, e.g., via ``tox -e py``)
+envlist = py34, py35, py36
 skip_missing_interpreters = true
 
 [testenv]
@@ -17,6 +17,9 @@ basepython = python3.4
 
 [testenv:py35]
 basepython = python3.5
+
+[testenv:py36]
+basepython = python3.6
 
 [testenv:py]
 # intentionally not setting basepython, thus using the invoking interpreter


### PR DESCRIPTION
* tox
* Travis CI
* AppVeyor