### PR TITLE
Improve the processing of config options

### DIFF
--- a/fuzzinator/call/anonymize_decorator.py
+++ b/fuzzinator/call/anonymize_decorator.py
@@ -1,12 +1,11 @@
-# Copyright (c) 2016-2018 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import json
-
+from ..config import as_list
 from . import CallableDecorator
 
 
@@ -49,7 +48,7 @@ class AnonymizeDecorator(CallableDecorator):
                     return issue
 
                 if properties:
-                    ks = json.loads(properties)
+                    ks = as_list(properties)
                 else:
                     ks = list(issue.keys())
 

--- a/fuzzinator/call/exit_code_filter.py
+++ b/fuzzinator/call/exit_code_filter.py
@@ -5,8 +5,7 @@
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import json
-
+from ..config import as_bool, as_list
 from . import CallableDecorator
 from . import NonIssue
 
@@ -46,8 +45,8 @@ class ExitCodeFilter(CallableDecorator):
     """
 
     def decorator(self, exit_codes, invert=False, **kwargs):
-        exit_codes = json.loads(exit_codes)
-        invert = invert in [1, '1', True, 'True', 'true']
+        exit_codes = as_list(exit_codes)
+        invert = as_bool(invert)
 
         def wrapper(fn):
             def filter(*args, **kwargs):

--- a/fuzzinator/call/file_writer_decorator.py
+++ b/fuzzinator/call/file_writer_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2018 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -7,6 +7,7 @@
 
 import os
 
+from ..config import as_path
 from . import CallableDecorator
 
 
@@ -45,7 +46,7 @@ class FileWriterDecorator(CallableDecorator):
         def wrapper(fn):
             def writer(*args, **kwargs):
                 file_content = kwargs['test']
-                file_path = filename.format(uid='{pid}-{id}'.format(pid=os.getpid(), id=id(self)))
+                file_path = as_path(filename.format(uid='{pid}-{id}'.format(pid=os.getpid(), id=id(self))))
                 if 'filename' in kwargs:
                     # Ensure that the test case will be saved to the directory defined by the
                     # config file and its name will be what is expected by the kwargs.

--- a/fuzzinator/call/gdb_backtrace_decorator.py
+++ b/fuzzinator/call/gdb_backtrace_decorator.py
@@ -1,14 +1,14 @@
-# Copyright (c) 2016-2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import json
 import os
 import pexpect
 
+from ..config import as_dict, as_pargs, as_path
 from . import CallableDecorator
 
 
@@ -62,9 +62,9 @@ class GdbBacktraceDecorator(CallableDecorator):
                     return issue
 
                 try:
-                    child = pexpect.spawn('gdb -ex "set width unlimited" -ex "set pagination off" --args {cmd}'.format(cmd=command.format(test=kwargs['test'])),
-                                          cwd=cwd or os.getcwd(),
-                                          env=dict(os.environ, **json.loads(env or '{}')))
+                    child = pexpect.spawn('gdb', ['-ex', 'set width unlimited', '-ex', 'set pagination off', '--args'] + as_pargs(command.format(test=kwargs['test'])),
+                                          cwd=as_path(cwd) if cwd else os.getcwd(),
+                                          env=dict(os.environ, **as_dict(env or '{}')))
                     child.expect_exact('(gdb) ')
                     child.sendline('run')
                     child.expect_exact('(gdb) ')

--- a/fuzzinator/call/lldb_backtrace_decorator.py
+++ b/fuzzinator/call/lldb_backtrace_decorator.py
@@ -1,14 +1,14 @@
-# Copyright (c) 2017-2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import json
 import os
 import pexpect
 
+from ..config import as_dict, as_pargs, as_path
 from . import CallableDecorator
 
 
@@ -67,9 +67,9 @@ class LldbBacktraceDecorator(CallableDecorator):
 
                 try:
                     expect_patterns = [r'\(lldb\) ', pexpect.EOF, pexpect.TIMEOUT]
-                    child = pexpect.spawn('lldb -X -- {cmd}'.format(cmd=command.format(test=kwargs['test'])),
-                                          cwd=cwd or os.getcwd(),
-                                          env=dict(os.environ, **json.loads(env or '{}')))
+                    child = pexpect.spawn('lldb', ['-X', '--'] + as_pargs(command.format(test=kwargs['test'])),
+                                          cwd=as_path(cwd) if cwd else os.getcwd(),
+                                          env=dict(os.environ, **as_dict(env or '{}')))
                     while child.expect(expect_patterns, timeout=timeout) == 0:
                         pass
                     child.sendline('run')

--- a/fuzzinator/call/regex_filter.py
+++ b/fuzzinator/call/regex_filter.py
@@ -1,13 +1,13 @@
-# Copyright (c) 2016-2018 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import json
 import re
 
+from ..config import as_list
 from . import CallableDecorator
 from . import NonIssue
 
@@ -45,7 +45,7 @@ class RegexFilter(CallableDecorator):
         patterns = dict()
         for (field, patterns_str) in kwargs.items():
             patterns[field] = []
-            for pattern in json.loads(patterns_str):
+            for pattern in as_list(patterns_str):
                 patterns[field].append(re.compile(pattern.encode('utf-8', errors='ignore'), flags=re.MULTILINE | re.DOTALL))
 
         def wrapper(fn):

--- a/fuzzinator/call/stdin_subprocess_call.py
+++ b/fuzzinator/call/stdin_subprocess_call.py
@@ -1,17 +1,15 @@
-# Copyright (c) 2016-2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import json
 import logging
 import os
-import shlex
 import subprocess
-import sys
 
+from ..config import as_bool, as_dict, as_pargs, as_path
 from .. import Controller
 from . import NonIssue
 
@@ -55,17 +53,17 @@ def StdinSubprocessCall(command, cwd=None, env=None, no_exit_code=None, test=Non
             cwd=/home/alice/foo
             env={"BAR": "1"}
     """
-    env = dict(os.environ, **json.loads(env)) if env else None
-    no_exit_code = no_exit_code in [1, '1', True, 'True', 'true']
+    env = dict(os.environ, **as_dict(env)) if env else None
+    no_exit_code = as_bool(no_exit_code)
     timeout = int(timeout) if timeout else None
     issue = {}
 
     try:
-        proc = subprocess.Popen(shlex.split(command, posix=sys.platform != 'win32'),
+        proc = subprocess.Popen(as_pargs(command),
                                 stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
-                                cwd=cwd or os.getcwd(),
+                                cwd=as_path(cwd) if cwd else os.getcwd(),
                                 env=env)
         stdout, stderr = proc.communicate(input=test, timeout=timeout)
         logger.debug('%s\n%s', stdout.decode('utf-8', errors='ignore'), stderr.decode('utf-8', errors='ignore'))

--- a/fuzzinator/call/subprocess_call.py
+++ b/fuzzinator/call/subprocess_call.py
@@ -1,17 +1,15 @@
-# Copyright (c) 2016-2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import json
 import logging
 import os
-import shlex
 import subprocess
-import sys
 
+from ..config import as_bool, as_dict, as_pargs, as_path
 from .. import Controller
 from . import NonIssue
 
@@ -61,16 +59,16 @@ def SubprocessCall(command, cwd=None, env=None, no_exit_code=None, test=None,
             cwd=/home/alice/foo
             env={"BAR": "1"}
     """
-    env = dict(os.environ, **json.loads(env)) if env else None
-    no_exit_code = no_exit_code in [1, '1', True, 'True', 'true']
+    env = dict(os.environ, **as_dict(env)) if env else None
+    no_exit_code = as_bool(no_exit_code)
     timeout = int(timeout) if timeout else None
     issue = {}
 
     try:
-        proc = subprocess.Popen(shlex.split(command.format(test=test), posix=sys.platform != 'win32'),
+        proc = subprocess.Popen(as_pargs(command.format(test=test)),
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
-                                cwd=cwd or os.getcwd(),
+                                cwd=as_path(cwd) if cwd else os.getcwd(),
                                 env=env)
         stdout, stderr = proc.communicate(timeout=timeout)
         logger.debug('%s\n%s', stdout.decode('utf-8', errors='ignore'), stderr.decode('utf-8', errors='ignore'))

--- a/fuzzinator/call/subprocess_property_decorator.py
+++ b/fuzzinator/call/subprocess_property_decorator.py
@@ -1,17 +1,15 @@
-# Copyright (c) 2016-2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import json
 import logging
 import os
-import shlex
 import subprocess
-import sys
 
+from ..config import as_dict, as_pargs, as_path
 from .. import Controller
 from . import CallableDecorator
 
@@ -63,11 +61,11 @@ class SubprocessPropertyDecorator(CallableDecorator):
                     return issue
 
                 try:
-                    proc = subprocess.Popen(shlex.split(command, posix=sys.platform != 'win32'),
-                                            cwd=cwd or os.getcwd(),
+                    proc = subprocess.Popen(as_pargs(command),
+                                            cwd=as_path(cwd) if cwd else os.getcwd(),
                                             stdout=subprocess.PIPE,
                                             stderr=subprocess.PIPE,
-                                            env=dict(os.environ, **json.loads(env or '{}')))
+                                            env=dict(os.environ, **as_dict(env or '{}')))
                     stdout, stderr = proc.communicate(timeout=timeout)
                     if proc.returncode == 0:
                         issue[property] = stdout

--- a/fuzzinator/call/test_runner_subprocess_call.py
+++ b/fuzzinator/call/test_runner_subprocess_call.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -7,15 +7,13 @@
 
 import errno
 import fcntl
-import json
 import logging
 import os
 import select
-import shlex
 import subprocess
-import sys
 import time
 
+from ..config import as_bool, as_dict, as_list, as_pargs, as_path
 from .. import Controller
 
 logger = logging.getLogger(__name__)
@@ -29,12 +27,12 @@ class TestRunnerSubprocessCall(object):
     """
 
     def __init__(self, command, cwd=None, env=None, end_texts=None, init_wait=None, timeout_per_test=None, **kwargs):
-        self.end_texts = json.loads(end_texts) if end_texts else []
-        self.init_wait = init_wait in [1, '1', True, 'True', 'true']
+        self.end_texts = as_list(end_texts) if end_texts else []
+        self.init_wait = as_bool(init_wait)
         self.timeout_per_test = int(timeout_per_test) if timeout_per_test else None
-        self.cwd = cwd or os.getcwd()
-        self.command = command
-        self.env = dict(os.environ, **json.loads(env)) if env else None
+        self.cwd = as_path(cwd) if cwd else os.getcwd()
+        self.command = as_pargs(command)
+        self.env = dict(os.environ, **as_dict(env)) if env else None
         self.proc = None
 
     def __enter__(self):
@@ -59,7 +57,7 @@ class TestRunnerSubprocessCall(object):
             return None
 
     def start(self, init_wait=True):
-        self.proc = subprocess.Popen(shlex.split(self.command, posix=sys.platform != 'win32'),
+        self.proc = subprocess.Popen(self.command,
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE,
                                      stdin=subprocess.PIPE,

--- a/fuzzinator/call/unique_id_decorator.py
+++ b/fuzzinator/call/unique_id_decorator.py
@@ -1,12 +1,11 @@
-# Copyright (c) 2016-2018 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import json
-
+from ..config import as_list
 from . import CallableDecorator
 
 
@@ -39,7 +38,7 @@ class UniqueIdDecorator(CallableDecorator):
     """
 
     def decorator(self, properties, **kwargs):
-        properties = json.loads(properties) if properties else None
+        properties = as_list(properties) if properties else None
 
         def wrapper(fn):
             def filter(*args, **kwargs):

--- a/fuzzinator/config.py
+++ b/fuzzinator/config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -7,11 +7,16 @@
 
 import hashlib
 import importlib
+import json
+import os
+import shlex
+import sys
 
 from collections import OrderedDict
 from configparser import ConfigParser, ExtendedInterpolation
 from inspect import isclass
 from io import StringIO
+from math import inf
 
 
 def import_entity(name):
@@ -140,3 +145,35 @@ def config_get_fuzzers(config):
         fuzzers[fuzzer] = dict(sut=sut, subconfig=hashlib.md5(src.encode('utf-8', errors='ignore')).hexdigest()[:9], src=src)
 
     return fuzzers
+
+
+def as_list(s):
+    if isinstance(s, list):
+        return s
+    return json.loads(s)
+
+
+def as_dict(s):
+    if isinstance(s, dict):
+        return s
+    return json.loads(s)
+
+
+def as_bool(s):
+    if isinstance(s, bool):
+        return s
+    return s in [1, '1', 'True', 'true']
+
+
+def as_int_or_inf(s):
+    if isinstance(s, int) or s == inf:
+        return s
+    return inf if s == 'inf' else int(s)
+
+
+def as_path(s):
+    return os.path.expanduser(os.path.expandvars(s))
+
+
+def as_pargs(s):
+    return [as_path(e) for e in shlex.split(s, posix=sys.platform != 'win32')]

--- a/fuzzinator/formatter/template_formatter.py
+++ b/fuzzinator/formatter/template_formatter.py
@@ -1,9 +1,11 @@
-# Copyright (c) 2018 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2018-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
+
+from ..config import as_path
 
 
 class TemplateFormatter(object):
@@ -32,11 +34,11 @@ class TemplateFormatter(object):
 
     def __init__(self, short='', short_file=None, long='', long_file=None):
         if short_file:
-            with open(short_file, 'r') as f:
+            with open(as_path(short_file), 'r') as f:
                 short = f.read()
 
         if long_file:
-            with open(long_file, 'r') as f:
+            with open(as_path(long_file), 'r') as f:
                 long = f.read()
 
         self.templates = {

--- a/fuzzinator/fuzzer/file_writer_decorator.py
+++ b/fuzzinator/fuzzer/file_writer_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -8,6 +8,8 @@
 import os
 
 from inspect import isclass, isroutine
+
+from ..config import as_path
 
 
 class FileWriterDecorator(object):
@@ -49,7 +51,7 @@ class FileWriterDecorator(object):
             def __init__(self, *args, **kwargs):
                 if hasattr(ancestor, '__init__'):
                     super().__init__(*args, **kwargs)
-                self.file_path = self.decorator.filename.format(uid='{pid}-{id}'.format(pid=os.getpid(), id=id(self)))
+                self.file_path = as_path(self.decorator.filename.format(uid='{pid}-{id}'.format(pid=os.getpid(), id=id(self))))
                 self.test = None
 
             def __enter__(self, *args, **kwargs):

--- a/fuzzinator/fuzzer/list_directory.py
+++ b/fuzzinator/fuzzer/list_directory.py
@@ -10,6 +10,8 @@ import os
 
 from pathlib import Path
 
+from ..config import as_bool, as_path
+
 logger = logging.getLogger(__name__)
 
 
@@ -51,7 +53,8 @@ class ListDirectory(object):
             pattern=/home/alice/foo-old-bugs/**/*.js
     """
     def __init__(self, pattern, contents=True, **kwargs):
-        self.contents = contents in [1, '1', True, 'True', 'true']
+        self.contents = as_bool(contents)
+        pattern = as_path(pattern)
         path = Path(pattern)
         anchor, pattern = ('.', pattern) if not path.anchor else (path.anchor, str(path.relative_to(path.anchor)))
         self.tests = [str(fn) for fn in Path(anchor).glob(pattern) if os.path.isfile(str(fn))]

--- a/fuzzinator/job/reduce_job.py
+++ b/fuzzinator/job/reduce_job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -7,7 +7,7 @@
 
 import os
 
-from ..config import config_get_callable
+from ..config import as_path, config_get_callable
 from .call_job import CallJob
 from .validate_job import ValidateJob
 
@@ -27,7 +27,7 @@ class ReduceJob(CallJob):
 
         self.issue = issue
         self.cost = int(config.get(sut_section, 'reduce_cost', fallback=config.get(sut_section, 'cost', fallback=1)))
-        self.work_dir = config.get('fuzzinator', 'work_dir')
+        self.work_dir = as_path(config.get('fuzzinator', 'work_dir'))
 
     def run(self):
         valid, issues = ValidateJob(id=self.id,

--- a/fuzzinator/reduce/picire.py
+++ b/fuzzinator/reduce/picire.py
@@ -8,11 +8,10 @@
 import logging
 import os
 
-from math import inf
-
 import chardet
 import picire
 
+from ..config import as_bool, as_int_or_inf
 from .picire_tester import PicireTester
 
 logger = logging.getLogger(__name__)
@@ -59,14 +58,14 @@ def Picire(sut_call, sut_call_kwargs, listener, ident, issue, work_dir,
     src = issue['test']
     file_name = issue.get('filename', 'test')
 
-    parallel = parallel in [1, '1', True, 'True', 'true']
-    jobs = 1 if not parallel else int(jobs)
+    parallel = as_bool(parallel)
+    jobs = int(jobs) if parallel else 1
     encoding = encoding or chardet.detect(src)['encoding']
-    granularity = int(granularity) if granularity != 'inf' else inf
-    cleanup = cleanup in [1, '1', True, 'True', 'true']
+    granularity = as_int_or_inf(granularity)
+    cleanup = as_bool(cleanup)
 
-    combine_loops = combine_loops in [1, '1', True, 'True', 'true']
-    subset_first = subset_first in [1, '1', True, 'True', 'true']
+    combine_loops = as_bool(combine_loops)
+    subset_first = as_bool(subset_first)
     max_utilization = int(max_utilization)
 
     split_method = getattr(picire.config_splitters, split_method)

--- a/fuzzinator/update/subprocess_update.py
+++ b/fuzzinator/update/subprocess_update.py
@@ -1,17 +1,15 @@
-# Copyright (c) 2016-2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import json
 import logging
 import os
-import shlex
 import subprocess
-import sys
 
+from ..config import as_dict, as_pargs, as_path
 from .. import Controller
 
 logger = logging.getLogger(__name__)
@@ -49,11 +47,11 @@ def SubprocessUpdate(command, cwd=None, env=None, timeout=None):
 
     timeout = int(timeout) if timeout else None
     try:
-        proc = subprocess.Popen(shlex.split(command, posix=sys.platform != 'win32'),
+        proc = subprocess.Popen(as_pargs(command),
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
-                                cwd=cwd or os.getcwd(),
-                                env=dict(os.environ, **json.loads(env or '{}')))
+                                cwd=as_path(cwd) if cwd else os.getcwd(),
+                                env=dict(os.environ, **as_dict(env or '{}')))
         stdout, stderr = proc.communicate(timeout=timeout)
         stdout_str = stdout.decode('utf-8', errors='ignore')
         if proc.returncode != 0:

--- a/fuzzinator/update/timestamp_update_condition.py
+++ b/fuzzinator/update/timestamp_update_condition.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2018 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2020 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -8,6 +8,8 @@
 import datetime
 import os
 import time
+
+from ..config import as_path
 
 
 def TimestampUpdateCondition(path, age):
@@ -37,7 +39,7 @@ def TimestampUpdateCondition(path, age):
             path=/home/alice/foo/bin/foo
             age=7:00:00:00
     """
-
+    path = as_path(path)
     if not os.path.exists(path):
         return True
 


### PR DESCRIPTION
- Added utility functions `as_bool`, `as_dict`, `as_int_or_inf`,
  `as_list`, `as_pargs`, and `as_path` to help the conversion of
  string parameters of various call, formatter, fuzzer, reducer,
  and updater building blocks.
- Improved the handling of file path parameters by applying
  environment variable and user home expansion to them in
  `as_path` (and `as_pargs`).
- Changed the default of `fuzzinator:work_dir` from
  `~/.fuzzinator-{uid}` to `~/.fuzzinator/{uid}` ensure that all
  Fuzzinator-related temp files go under a single directory (in the
  default case). Also fixed code to use this default.

Note: the config parser of Fuzzinator uses extended interpolation,
which uses `${section:option}` syntax. This is the expansion that
is applied first to any value in the config files. Thus, to
reference environment variables in paths, their names must be
prefixed with `$$` (e.g.,
`work_dir=$$XDG_RUNTIME_DIR/fuzzinator/{uid}`).