### PR TITLE
Remove kill_process_tree and use communicate on the killed process

### DIFF
--- a/fuzzinator/call/subprocess_call.py
+++ b/fuzzinator/call/subprocess_call.py
@@ -82,6 +82,7 @@ def SubprocessCall(command, cwd=None, env=None, no_exit_code=None, test=None,
             return issue
     except subprocess.TimeoutExpired:
         logger.debug('Timeout expired in the SUT\'s subprocess runner.')
-        Controller.kill_process_tree(proc.pid)
+        proc.kill()
+        proc.communicate()
 
     return NonIssue(issue) if issue else None

--- a/fuzzinator/call/subprocess_call.py
+++ b/fuzzinator/call/subprocess_call.py
@@ -10,7 +10,6 @@ import os
 import subprocess
 
 from ..config import as_bool, as_dict, as_pargs, as_path
-from .. import Controller
 from . import NonIssue
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This ensures no zombie processes are left behind.