### PR TITLE
Disable consider-using-f-string pylint diagnostics

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -28,7 +28,7 @@ disable=
     import-outside-toplevel, consider-using-with, deprecated-module,
     consider-using-dict-items, too-many-boolean-expressions,
     unspecified-encoding, use-dict-literal, use-list-literal,
-    redundant-u-string-prefix, bad-super-call
+    redundant-u-string-prefix, bad-super-call, consider-using-f-string
 
 [TYPECHECK]
 


### PR DESCRIPTION
As Fuzzinator still supports Python 3.5, f-strings are not an
option, yet.