### PR TITLE
Disable debug on the app of TornadoDecorator

### DIFF
--- a/fuzzinator/fuzzer/tornado_decorator.py
+++ b/fuzzinator/fuzzer/tornado_decorator.py
@@ -168,7 +168,7 @@ class TornadoDecorator(FuzzerDecorator):
             app = Application(handlers,
                               template_path=self.template_path,
                               static_path=self.static_path,
-                              debug=True)
+                              debug=False)
             app.listen(obj._port, ssl_options=self.ssl_ctx)
 
             # Run the event loop and the application within.


### PR DESCRIPTION
Forcing debug mode on TornadoDecorator implied to reload the whole
tornado service, including the tornado serving the WUI. This may
cause unexpected failures, hence disabling it.