### PR TITLE
Simplify the uses of `dict.update()`

### DIFF
--- a/fuzzinator/fuzzer/afl_runner.py
+++ b/fuzzinator/fuzzer/afl_runner.py
@@ -87,7 +87,7 @@ class AFLRunner(Fuzzer):
         self.sut_command = as_pargs(sut_command.format(test='@@'))
         self.cwd = as_path(cwd) if cwd else None
         self.env = as_dict(env) if env else dict()
-        self.env.update({'AFL_NO_UI': '1'})
+        self.env.update(AFL_NO_UI='1')
         self.timeout = timeout
         self.dictionary = as_path(dictionary) if dictionary else None
         self.master_name = master_name

--- a/fuzzinator/job/call_job.py
+++ b/fuzzinator/job/call_job.py
@@ -26,12 +26,12 @@ class CallJob(object):
         test = issue['test']
 
         # Save issue details.
-        issue.update(dict(sut=self.sut_name,
-                          fuzzer=self.fuzzer_name,
-                          subconfig=dict(subconfig=self.subconfig_id),
-                          test=test,
-                          reduced=None,
-                          reported=False))
+        issue.update(sut=self.sut_name,
+                     fuzzer=self.fuzzer_name,
+                     subconfig=dict(subconfig=self.subconfig_id),
+                     test=test,
+                     reduced=None,
+                     reported=False)
 
         # Generate default hash ID for the test if does not exist.
         self.ensure_id(issue)

--- a/fuzzinator/reduce/picire_common.py
+++ b/fuzzinator/reduce/picire_common.py
@@ -87,9 +87,9 @@ class PicireReducer(Reducer):
                 self.reduce_config = dict(subset_iterator=subset_iterator,
                                           complement_iterator=complement_iterator,
                                           subset_first=subset_first)
-            self.reduce_config.update(dict(proc_num=jobs,
-                                           max_utilization=max_utilization))
-        self.reduce_config.update(dict(split=split_class(n=granularity)))
+            self.reduce_config.update(proc_num=jobs,
+                                      max_utilization=max_utilization)
+        self.reduce_config.update(split=split_class(n=granularity))
 
     TestTuple = namedtuple('TestTuple', ['src', 'encoding'])
     TesterTuple = namedtuple('TesterTuple', ['tester_class', 'tester_config', 'new_issues'])


### PR DESCRIPTION
`dict.update()` accepts keyword arguments, so it is unnecessary to
use `d.update(dict(foo=bar))`, one can simply write
`d.update(foo=bar)` instead.