### PR TITLE
Drop support of Python3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,20 +6,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
         exclude:
           # NOTE: pynacl should not be built from sdist, but it has no binary
           # wheel available for windows+pypy
           - os: windows-latest
             python-version: 'pypy-3.7'
-          # Python3.5 and Python3.6 are only available in GH Actions up to Ubuntu 20.04.
-          - os: ubuntu-latest
-            python-version: '3.5'
+          # Python3.6 is only available in GH Actions up to Ubuntu 20.04.
           - os: ubuntu-latest
             python-version: '3.6'
         include:
-          - os: ubuntu-20.04
-            python-version: '3.5'
           - os: ubuntu-20.04
             python-version: '3.6'
     runs-on: ${{ matrix.os }}

--- a/.pylintrc
+++ b/.pylintrc
@@ -27,7 +27,7 @@ disable=
     abstract-method, arguments-differ, cyclic-import, bad-whitespace,
     import-outside-toplevel, consider-using-with, deprecated-module,
     consider-using-dict-items, too-many-boolean-expressions,
-    unspecified-encoding, bad-super-call, consider-using-f-string,
+    unspecified-encoding, bad-super-call,
     attribute-defined-outside-init
 
 [TYPECHECK]

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ interfaces:
 Requirements
 ============
 
-* Python_ >= 3.5
+* Python_ >= 3.6
 * MongoDB_ >= 3.6 (either local installation or access to remote database)
 * Java_ SE >= 7 JRE or JDK (optional, required if the *Picireny* test case
   reducer is used)

--- a/fuzzinator/call/regex_automaton.py
+++ b/fuzzinator/call/regex_automaton.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -72,7 +72,7 @@ class RegexAutomaton(object):
             elif field_op == 'n':
                 pass
             else:
-                raise ValueError('Unknown instruction for operation on fields: %s.' % field_op)
+                raise ValueError(f'Unknown instruction for operation on fields: {field_op}.')
 
             # Terminate pattern matching and return with the current result.
             if next_line_op == 't':
@@ -84,7 +84,7 @@ class RegexAutomaton(object):
             if next_line_op == 'c':
                 pass
             else:
-                raise ValueError('Unknown instruction for input processing: %s.' % next_line_op)
+                raise ValueError(f'Unknown instruction for input processing: {next_line_op}.')
 
         return False, updated
 

--- a/fuzzinator/call/subprocess_property_decorator.py
+++ b/fuzzinator/call/subprocess_property_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -76,13 +76,13 @@ class SubprocessPropertyDecorator(CallDecorator):
                                     check=True)
             issue[self.property] = decode(result.stdout, self.encoding)
         except subprocess.TimeoutExpired as e:
-            logger.warning('SubprocessPropertyDecorator execution timeout (%ds) expired while setting the \'%s\' property.\n%s\n%s',
+            logger.warning('SubprocessPropertyDecorator execution timeout (%ds) expired while setting the %r property.\n%s\n%s',
                            e.timeout,
                            self.property,
                            decode(e.stdout or b'', self.encoding),
                            decode(e.stderr or b'', self.encoding))
         except subprocess.CalledProcessError as e:
-            logger.warning('SubprocessPropertyDecorator exited with nonzero exit code (%d) while setting the \'%s\' property.\n%s\n%s',
+            logger.warning('SubprocessPropertyDecorator exited with nonzero exit code (%d) while setting the %r property.\n%s\n%s',
                            e.returncode,
                            self.property,
                            decode(e.stdout, self.encoding),

--- a/fuzzinator/call/test_runner_subprocess_call.py
+++ b/fuzzinator/call/test_runner_subprocess_call.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -52,7 +52,7 @@ class TestRunnerSubprocessCall(Call):
             self.start(self.init_wait)
 
         try:
-            self.proc.stdin.write((test + '\n').encode('utf-8'))
+            self.proc.stdin.write(f'{test}\n'.encode('utf-8'))
             self.proc.stdin.flush()
             return self.wait_til_end()
         except Exception:

--- a/fuzzinator/executor.py
+++ b/fuzzinator/executor.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 # Copyright (c) 2019 Tamas Keri.
 #
 # Licensed under the BSD 3-Clause License
@@ -37,12 +37,12 @@ def process_args(args):
 
     parsed_fn = config.read(args.config)
     if len(parsed_fn) != len(args.config):
-        return 'Config file(s) do(es) not exist: {fn}'.format(fn=', '.join(fn for fn in args.config if fn not in parsed_fn))
+        return f'Config file(s) do(es) not exist: {", ".join(fn for fn in args.config if fn not in parsed_fn)}'
 
     for define in args.defines:
         parts = re.fullmatch('([^:=]*):([^:=]*)=(.*)', define)
         if not parts:
-            return 'Config option definition not in SECT:OPT=VAL format: {d}'.format(d=define)
+            return f'Config option definition not in SECT:OPT=VAL format: {define}'
 
         section, option, value = parts.group(1, 2, 3)
         if not config.has_section(section):
@@ -52,7 +52,7 @@ def process_args(args):
     for undef in args.undefs:
         parts = re.fullmatch('([^:=]*)(:([^:=]*))?', undef)
         if not parts:
-            return 'Config section/option undefinition not in SECT[:OPT] format: {u}'.format(u=undef)
+            return f'Config section/option undefinition not in SECT[:OPT] format: {undef}'
 
         section, option = parts.group(1, 3)
         if option is None:

--- a/fuzzinator/fuzzer/afl_runner.py
+++ b/fuzzinator/fuzzer/afl_runner.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -125,7 +125,7 @@ class AFLRunner(Fuzzer):
                 self.sut_command
 
             child = pexpect.spawn(self.afl_fuzz, command, cwd=self.cwd, env=self.env)
-            child.expect(['Fuzzing test case [#]{next_it}.*'.format(next_it=self.iteration), pexpect.EOF], timeout=None)
+            child.expect([f'Fuzzing test case [#]{self.iteration}.*', pexpect.EOF], timeout=None)
             child.terminate(force=True)
 
             self.tests = [os.path.join(crash_dir, test) for test in os.listdir(crash_dir) if test.startswith('id') and test not in self.checked]

--- a/fuzzinator/fuzzer/tornado_decorator.py
+++ b/fuzzinator/fuzzer/tornado_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -79,7 +79,7 @@ class TornadoDecorator(FuzzerDecorator):
     def __init__(self, *, template_path=None, static_path=None, url=None, refresh=None, certfile=None, keyfile=None, **kwargs):
         self.template_path = template_path
         self.static_path = static_path
-        self.url = url or ('https' if certfile else 'http') + '://localhost:{port}?index={index}'
+        self.url = url or f'{"https" if certfile else "http"}://localhost:{{port}}?index={{index}}'
         self.refresh = int(refresh) if refresh else 0
         if certfile:
             self.ssl_ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
@@ -108,7 +108,7 @@ class TornadoDecorator(FuzzerDecorator):
         return self.url.format(port=obj._port, index=obj.index)
 
     def _service(self, obj):
-        return '{scheme}://localhost:{port}'.format(scheme='https' if self.ssl_ctx else 'http', port=obj._port)
+        return f'{"https" if self.ssl_ctx else "http"}://localhost:{obj._port}'
 
     def call(self, cls, obj, *, index):
         if index != 0 and obj.test is None:
@@ -131,9 +131,7 @@ class TornadoDecorator(FuzzerDecorator):
                     if obj.test is not None:
                         obj.index += 1
                         if decorator.refresh > 0:
-                            self.set_header('Refresh', '{timeout}; url={url}'
-                                            .format(timeout=decorator.refresh,
-                                                    url=decorator._url(obj)))
+                            self.set_header('Refresh', f'{decorator.refresh}; url={decorator._url(obj)}')
                         test = obj.test
                         if not isinstance(test, (str, bytes, dict)):
                             test = str(test)
@@ -145,7 +143,7 @@ class TornadoDecorator(FuzzerDecorator):
 
             def get(self, page):
                 try:
-                    self.render(page + '.html')
+                    self.render(f'{page}.html')
                 except FileNotFoundError:
                     logger.debug('%s not found', page)
                     self.send_error(404)

--- a/fuzzinator/job/fuzz_job.py
+++ b/fuzzinator/job/fuzz_job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -18,17 +18,17 @@ class FuzzJob(CallJob):
     """
 
     def __init__(self, id, config, subconfig_id, fuzzer_name, db, listener):
-        fuzz_section = 'fuzz.' + fuzzer_name
+        fuzz_section = f'fuzz.{fuzzer_name}'
         sut_name = config.get(fuzz_section, 'sut')
         super().__init__(id, config, subconfig_id, sut_name, fuzzer_name, db, listener)
 
         capacity = int(config.get('fuzzinator', 'cost_budget'))
-        self.cost = min(int(config.get('sut.' + sut_name, 'cost', fallback=1)), capacity)
+        self.cost = min(int(config.get(f'sut.{sut_name}', 'cost', fallback=1)), capacity)
         self.batch = float(config.get(fuzz_section, 'batch', fallback=1))
         self.refresh = float(config.get(fuzz_section, 'refresh', fallback=self.batch))
 
     def run(self):
-        fuzzer = config_get_object(self.config, 'fuzz.' + self.fuzzer_name, 'fuzzer')
+        fuzzer = config_get_object(self.config, f'fuzz.{self.fuzzer_name}', 'fuzzer')
 
         # Register signal handler to catch keyboard interrupts.
         def terminate(signum, frame):
@@ -46,7 +46,7 @@ class FuzzJob(CallJob):
         self.listener.on_stats_updated()
         with fuzzer:
             while index < self.batch:
-                sut_call = config_get_object(self.config, 'sut.' + self.sut_name, 'call')
+                sut_call = config_get_object(self.config, f'sut.{self.sut_name}', 'call')
                 with sut_call:
                     while index < self.batch:
                         test = fuzzer(index=index)
@@ -68,7 +68,7 @@ class FuzzJob(CallJob):
 
                         if issue and test is None:
                             self.batch = index
-                            self.listener.warning(job_id=self.id, msg='{sut} crashed before the first test.'.format(sut=self.sut_name))
+                            self.listener.warning(job_id=self.id, msg=f'{self.sut_name} crashed before the first test.')
                             break
 
                         if issue is not None and ('test' not in issue or not issue['test']):

--- a/fuzzinator/job/reduce_job.py
+++ b/fuzzinator/job/reduce_job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -19,9 +19,8 @@ class ReduceJob(CallJob):
 
     def __init__(self, id, config, issue, db, listener):
         sut_name = issue['sut']
-        sut_section = 'sut.' + sut_name
-        fuzzer_name = '{fuzzer}/{reducer}'.format(fuzzer=issue['fuzzer'].split('/')[0],
-                                                  reducer=config.get(sut_section, 'reduce'))
+        sut_section = f'sut.{sut_name}'
+        fuzzer_name = f'{issue["fuzzer"].split("/")[0]}/{config.get(sut_section, "reduce")}'
         subconfig_id = issue['subconfig'].get('subconfig') if isinstance(issue.get('subconfig'), dict) else None
         super().__init__(id, config, subconfig_id, sut_name, fuzzer_name, db, listener)
 
@@ -38,7 +37,7 @@ class ReduceJob(CallJob):
         if not valid:
             return issues
 
-        sut_section = 'sut.' + self.sut_name
+        sut_section = f'sut.{self.sut_name}'
         sut_call = config_get_object(self.config, sut_section, ['reduce_call', 'validate_call', 'call'])
         reduce = config_get_object(self.config, sut_section, 'reduce')
 
@@ -47,7 +46,7 @@ class ReduceJob(CallJob):
                                          on_job_progressed=partial(self.listener.on_job_progressed, job_id=self.id))
 
         if reduced_src is None:
-            self.listener.warning(job_id=self.id, msg='Reduce of {issue_id} failed.'.format(issue_id=self.issue['id']))
+            self.listener.warning(job_id=self.id, msg=f'Reduce of {self.issue["id"]} failed.')
         else:
             self.db.update_issue_by_oid(self.issue['_id'], {'reduced': reduced_src})
             self.listener.on_issue_reduced(job_id=self.id, issue=self.issue)

--- a/fuzzinator/job/update_job.py
+++ b/fuzzinator/job/update_job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -17,9 +17,9 @@ class UpdateJob(object):
         self.config = config
         self.sut_name = sut_name
         capacity = int(config.get('fuzzinator', 'cost_budget'))
-        self.cost = min(int(config.get('sut.' + sut_name, 'update_cost', fallback=config.get('fuzzinator', 'cost_budget'))), capacity)
+        self.cost = min(int(config.get(f'sut.{sut_name}', 'update_cost', fallback=config.get('fuzzinator', 'cost_budget'))), capacity)
 
     def run(self):
-        update = config_get_object(self.config, 'sut.' + self.sut_name, 'update')
+        update = config_get_object(self.config, f'sut.{self.sut_name}', 'update')
         update()
         return []

--- a/fuzzinator/job/validate_job.py
+++ b/fuzzinator/job/validate_job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -18,7 +18,7 @@ class ValidateJob(CallJob):
 
     def __init__(self, id, config, issue, db, listener):
         sut_name = issue['sut']
-        sut_section = 'sut.' + sut_name
+        sut_section = f'sut.{sut_name}'
         fuzzer_name = issue['fuzzer']
         subconfig_id = issue['subconfig'].get('subconfig') if isinstance(issue.get('subconfig'), dict) else None
         super().__init__(id, config, subconfig_id, sut_name, fuzzer_name, db, listener)
@@ -32,7 +32,7 @@ class ValidateJob(CallJob):
         return new_issues
 
     def validate(self):
-        sut_call = config_get_object(self.config, 'sut.' + self.sut_name, ['validate_call', 'call'])
+        sut_call = config_get_object(self.config, f'sut.{self.sut_name}', ['validate_call', 'call'])
         with sut_call:
             issue = sut_call(**self.issue)
 

--- a/fuzzinator/listener/email_listener.py
+++ b/fuzzinator/listener/email_listener.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -52,7 +52,7 @@ class EmailListener(EventListener):
 
             pwd = keyring.get_password('fuzzinator', self.from_address)
             while not pwd:
-                pwd = getpass.getpass(prompt='Password of {mail}: '.format(mail=self.from_address))
+                pwd = getpass.getpass(prompt=f'Password of {self.from_address!r}: ')
                 try:
                     server.login(self.from_address, pwd)
                 except Exception as e:
@@ -74,7 +74,7 @@ class EmailListener(EventListener):
         data = dict((name, raw.decode('utf-8', 'ignore') if isinstance(raw, bytes) else raw) for name, raw in data.items())
 
         from ..formatter import JsonFormatter
-        formatter = config_get_object(self.config, 'sut.' + data['sut'], ['email_formatter', 'formatter']) or JsonFormatter()
+        formatter = config_get_object(self.config, f'sut.{data["sut"]}', ['email_formatter', 'formatter']) or JsonFormatter()
 
         subject = formatter.summary(issue=data)
         content = formatter(issue=data)

--- a/fuzzinator/listener/listener_manager.py
+++ b/fuzzinator/listener/listener_manager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2018-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -24,7 +24,7 @@ class Trampoline(object):
             try:
                 getattr(listener, self.name)(**kwargs)
             except Exception as e:
-                logger.warning('Unhandled exception in listener \'%s\'.', self.name, exc_info=e)
+                logger.warning('Unhandled exception in listener %r.', self.name, exc_info=e)
 
 
 class ListenerManager(object):

--- a/fuzzinator/tracker/bugzilla_tracker.py
+++ b/fuzzinator/tracker/bugzilla_tracker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -78,7 +78,7 @@ class BugzillaTracker(Tracker):
             bug = self.bzapi.createbug(create_info)
             if test:
                 with (BytesIO if isinstance(test, bytes) else StringIO)(test) as f:
-                    self.bzapi.attachfile(idlist=bug.bug_id, attachfile=f, description='Test', is_patch=False, file_name='test.{ext}'.format(ext=extension), content_type='text/plain')
+                    self.bzapi.attachfile(idlist=bug.bug_id, attachfile=f, description='Test', is_patch=False, file_name=f'test.{extension}', content_type='text/plain')
 
             if blocks:
                 self.bzapi.update_bugs(ids=bug.bug_id, updates=self.bzapi.build_update(blocks_add=blocks))

--- a/fuzzinator/tracker/github_tracker.py
+++ b/fuzzinator/tracker/github_tracker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -52,7 +52,7 @@ class GithubTracker(Tracker):
 
     def find_duplicates(self, *, title):
         try:
-            issues = list(self.ghapi.search_issues('repo:{repository} is:issue is:open {title}'.format(repository=self.repository, title=title)))
+            issues = list(self.ghapi.search_issues(f'repo:{self.repository} is:issue is:open {title}'))
             return [(issue.html_url, issue.title) for issue in issues]
         except GithubException as e:
             raise TrackerError('Finding possible duplicates failed') from e

--- a/fuzzinator/ui/tui/dialogs.py
+++ b/fuzzinator/ui/tui/dialogs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -68,20 +68,11 @@ class AboutDialog(Dialog):
                          footer_btns=[FormattedButton('Close', lambda button: self._emit('close'))])
 
     def compile_about_data(self, prop_width=15):
-        return '{name_prop}: {name}\n' \
-               '{version_prop}: {version}\n' \
-               '{authors_prop}: {authors}\n' \
-               '{mail_prop}: {email}\n' \
-               '{homepage_prop}: {homepage}\n'.format(name_prop='Name'.ljust(prop_width),
-                                                      name=__pkg_name__,
-                                                      version_prop='Version'.ljust(prop_width),
-                                                      version=__version__,
-                                                      authors_prop='Authors'.ljust(prop_width),
-                                                      authors=__author__,
-                                                      mail_prop='E-mail'.ljust(prop_width),
-                                                      email=__author_email__,
-                                                      homepage_prop='Homepage'.ljust(prop_width),
-                                                      homepage=__url__)
+        return f'{"Name":<{prop_width}}: {__pkg_name__}\n' \
+               f'{"Version":<{prop_width}}: {__version__}\n' \
+               f'{"Authors":<{prop_width}}: {__author__}\n' \
+               f'{"E-mail":<{prop_width}}: {__author_email__}\n' \
+               f'{"Homepage":<{prop_width}}: {__url__}\n'
 
 
 class WarningDialog(Dialog):
@@ -119,7 +110,7 @@ class FormattedIssueDialog(Dialog):
     exit_keys = ['esc', 'f3']
 
     def __init__(self, config, issue, db):
-        formatter = config_get_object(config, 'sut.' + issue['sut'], ['tui_formatter', 'formatter']) or JsonFormatter()
+        formatter = config_get_object(config, f'sut.{issue["sut"]}', ['tui_formatter', 'formatter']) or JsonFormatter()
         super().__init__(title=formatter.summary(issue=issue),
                          body=[Padding(Text(line, wrap='clip'), left=2, right=2) for line in formatter(issue=issue).splitlines()],
                          footer_btns=[FormattedButton('Close', lambda button: self._emit('close'))])
@@ -155,7 +146,7 @@ class EditIssueDialog(Dialog):
                 continue
 
             self.edit_boxes[prop] = BugEditor('', self._to_str(prop, issue[prop]), multiline=True)
-            rows.append(Columns([('weight', 1, Text(('dialog_secondary', prop + ': '))),
+            rows.append(Columns([('weight', 1, Text(('dialog_secondary', f'{prop}: '))),
                                  ('weight', 10, self.edit_boxes[prop])], dividechars=1))
 
         super().__init__(title=issue['id'],

--- a/fuzzinator/ui/tui/graphics.py
+++ b/fuzzinator/ui/tui/graphics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -22,13 +22,13 @@ def fz_logo_4lines():
     padding = ''.join([' '] * (len(short_version) + 2)) + '\n'
     if util.get_encoding_mode() == 'utf8':
         return [
-            ('logo', ' ▄▄▄▄ ▄▄ ▄▄ ▄▄▄▄▄ ▄▄▄▄▄ ▄▄ ▄▄▄▄   ▄▄▄  █▄     ▄▄▄  ▄▄▄▄  '), ('logo_secondary', '[{version}]\n'.format(version=short_version)),
+            ('logo', ' ▄▄▄▄ ▄▄ ▄▄ ▄▄▄▄▄ ▄▄▄▄▄ ▄▄ ▄▄▄▄   ▄▄▄  █▄     ▄▄▄  ▄▄▄▄  '), ('logo_secondary', f'[{short_version}]\n'),
             ('logo', '██ ▀▀ ██ ██   ▄█▀   ▄█▀ ▄▄ ██ ██ ▀▀ ██ ██▀   ██ ██ ██ ██ '), ('logo_secondary', padding),
             ('logo', '██▀   ██ ██ ▄█▀   ▄█▀   ██ ██ ██ ▄█▀██ ██ ██ ██ ██ ██▀█▄ '), ('logo_secondary', padding),
             ('logo', '█▀     ▀▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀▀ ▀▀ ▀▀ ▀▀▀▀▀  ▀▀▀▀  ▀▀▀  ▀▀ ▀█ '), ('logo_secondary', padding),
             ('logo_secondary', 'In Bug We Trust.')]
     return [
-        ('logo', ' #### ## ## ##### ##### ## ####  ####  ##     ###  ####  '), ('logo_secondary', '[{version}]\n'.format(version=short_version)),
+        ('logo', ' #### ## ## ##### ##### ## ####  ####  ##     ###  ####  '), ('logo_secondary', f'[{short_version}]\n'),
         ('logo', '##    ## ##   ###   ###    ## ##   ### ###   ## ## ## ## '), ('logo_secondary', padding),
         ('logo', '###   ## ## ###   ###   ## ## ## ## ## ##    ## ## ####  '), ('logo_secondary', padding),
         ('logo', '##     ###  ##### ##### ## ## ## #####  ####  ###  ## ## '), ('logo_secondary', padding),

--- a/fuzzinator/ui/tui/popup_buttons.py
+++ b/fuzzinator/ui/tui/popup_buttons.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -101,7 +101,7 @@ class ReportButton(FullScreenPopupLauncher):
             return None
         issue = self.issues_table.db.find_issue_by_oid(focus.data['_id'])
 
-        tracker = config_get_object(self.config, 'sut.' + issue['sut'], 'tracker')
+        tracker = config_get_object(self.config, f'sut.{issue["sut"]}', 'tracker')
         if tracker:
             dialog = tracker.ui_extension.get('tui')
             popup_cls = import_object(dialog) if dialog else ReportDialog

--- a/fuzzinator/ui/tui/reporter_dialogs.py
+++ b/fuzzinator/ui/tui/reporter_dialogs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -41,10 +41,10 @@ class ReportDialog(PopUpTarget):
         self.issue = issue
         self.db = db
 
-        self.tracker = config_get_object(config, 'sut.' + issue['sut'], 'tracker')
+        self.tracker = config_get_object(config, f'sut.{issue["sut"]}', 'tracker')
         self.settings = self.tracker.settings()
 
-        formatter = config_get_object(config, 'sut.' + issue['sut'], 'formatter') or JsonFormatter()
+        formatter = config_get_object(config, f'sut.{issue["sut"]}', 'formatter') or JsonFormatter()
         self.issue_title = BugEditor(edit_text=formatter.summary(issue=issue))
         self.issue_desc = BugEditor(edit_text=formatter(issue=issue), multiline=True, wrap='clip')
 

--- a/fuzzinator/ui/tui/table.py
+++ b/fuzzinator/ui/tui/table.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -178,9 +178,9 @@ class TableColumn(object):
         if v is None:
             v = ''
         elif isinstance(v, int):
-            v = '%d' % v
+            v = str(v)
         elif isinstance(v, float):
-            v = '%.03f' % v
+            v = f'{v:.03f}'
 
         # If v doesn't match any of the previous options than it might be a Widget.
         if not isinstance(v, Widget):
@@ -310,7 +310,7 @@ class TableRow(WidgetWrap):
         elif isinstance(table.border, int):
             border_width = table.border
         else:
-            raise Exception('Invalid border specification: %s' % table.border)
+            raise Exception(f'Invalid border specification: {table.border}')
 
         self.row = self.column_class(self.contents)
         if self.header:
@@ -454,7 +454,7 @@ class Table(WidgetWrap):
         self.pile = Pile([('pack', self.header),
                           ('weight', 1, self.listbox)])
 
-        self.pattern_box = PatternBox(self.pile, title=['[', ('border_title', ' {title} (0) '.format(title=self.title)), ']'], **fz_box_pattern())
+        self.pattern_box = PatternBox(self.pile, title=['[', ('border_title', f' {self.title} (0) '), ']'], **fz_box_pattern())
         self.attr = AttrMap(self.pattern_box, attr_map=self.attr_map)
         super().__init__(self.attr)
 
@@ -466,7 +466,7 @@ class Table(WidgetWrap):
             self.requery(self.query_data)
 
     def update_header(self):
-        self.pattern_box.set_title(['[', ('border_title', ' {title} ({cnt}) '.format(title=self.title, cnt=len(self.walker))), ']'])
+        self.pattern_box.set_title(['[', ('border_title', f' {self.title} ({len(self.walker)}) '), ']'])
 
     def __delitem__(self, i):
         del self.body[i]
@@ -618,7 +618,7 @@ class Table(WidgetWrap):
             sort_field = self.columns[index // 2].name
 
         if not isinstance(index, int):
-            raise Exception('invalid column index: %s' % index)
+            raise Exception(f'invalid column index: {index}')
 
         if reverse is not None:
             self.sort_reverse = reverse ^ self.columns[index // 2].sort_reverse

--- a/fuzzinator/ui/tui/widgets.py
+++ b/fuzzinator/ui/tui/widgets.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -115,8 +115,8 @@ class MainWindow(PopUpLauncher):
     def add_reduce_job(self):
         if self.issues_table.selection:
             issue = self.db.find_issue_by_oid(self.issues_table.selection.data['_id'])
-            if not self.config.has_section('sut.' + issue['sut']):
-                self.warning_popup(msg='{sut} is not defined.'.format(sut=issue['sut']))
+            if not self.config.has_section(f'sut.{issue["sut"]}'):
+                self.warning_popup(msg=f'{issue["sut"]} is not defined.')
             else:
                 self.controller.add_reduce_job(issue)
 
@@ -127,7 +127,7 @@ class MainWindow(PopUpLauncher):
         if self.issues_table.selection:
             issue = self.db.find_issue_by_oid(self.issues_table.selection.data['_id'])
             if not self.controller.add_validate_job(issue):
-                self.warning_popup(msg='{sut} is not defined.'.format(sut=issue['sut']))
+                self.warning_popup(msg=f'{issue["sut"]} is not defined.')
 
     def copy_selected(self, test_bytes=False):
         if self.issues_table.selection:
@@ -135,7 +135,7 @@ class MainWindow(PopUpLauncher):
             if test_bytes:
                 pyperclip.copy(str(issue['test']))
             else:
-                formatter = config_get_object(self.config, 'sut.' + issue['sut'], ['tui_formatter', 'formatter']) or JsonFormatter()
+                formatter = config_get_object(self.config, f'sut.{issue["sut"]}', ['tui_formatter', 'formatter']) or JsonFormatter()
                 pyperclip.copy(formatter(issue=issue))
 
     def keypress(self, size, key):
@@ -339,11 +339,11 @@ class JobsTable(WidgetWrap):
 
     @property
     def title(self):
-        return ['[', ('border_title', ' {txt} '.format(txt=self.title_text)), ']']
+        return ['[', ('border_title', f' {self.title_text} '), ']']
 
     @title.setter
     def title(self, value):
-        self.pattern_box.set_title(['[', ('border_title', ' JOBS ({cnt}) '.format(cnt=value)), ']'])
+        self.pattern_box.set_title(['[', ('border_title', f' JOBS ({value}) '), ']'])
 
     @property
     def active_jobs(self):
@@ -560,16 +560,13 @@ class TimerWidget(Text):
         super().__init__(self.format_text(0))
         self.update()
 
-    def to_hms(self, ss):
+    def format_text(self, ss):
         hh = ss // 3600
         r = ss - hh * 3600
         mm = r // 60
         # truncate to first digit after decimal
         ss = (r - mm * 60)
-        return hh, mm, ss
-
-    def format_text(self, ss):
-        return '%02d:%02d:%04.1f' % self.to_hms(ss)
+        return f'{hh:02.0f}:{mm:02.0f}:{ss:04.1f}'
 
     def update(self):
         self.set_text(('time', self.format_text(time.time() - self._started)))

--- a/fuzzinator/ui/wui/ui_handlers.py
+++ b/fuzzinator/ui/wui/ui_handlers.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2019 Tamas Keri.
-# Copyright (c) 2019-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2019-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -71,7 +71,7 @@ class BaseUIHandler(RequestHandler):
         if 'exc_info' in kwargs:
             icon = 'sentiment_very_dissatisfied'
             if self.application.settings.get('serve_traceback'):
-                exc_info = markdown('```\n%s\n```' % ''.join(traceback.format_exception(*kwargs['exc_info'])), extensions=['extra', 'fenced_code', 'codehilite'])
+                exc_info = markdown(f'```\n{"".join(traceback.format_exception(*kwargs["exc_info"]))}\n```', extensions=['extra', 'fenced_code', 'codehilite'])
             else:
                 exc_info = ''
         else:
@@ -94,13 +94,13 @@ class IssueUIHandler(BaseUIHandler):
             self.send_error(404)
             return
 
-        formatter = config_get_object(self._config, 'sut.' + issue['sut'], ['wui_formatter', 'formatter']) or JsonFormatter()
-        exporter = config_get_object(self._config, 'sut.' + issue['sut'], 'exporter')
+        formatter = config_get_object(self._config, f'sut.{issue["sut"]}', ['wui_formatter', 'formatter']) or JsonFormatter()
+        exporter = config_get_object(self._config, f'sut.{issue["sut"]}', 'exporter')
 
         self.render('issue.html',
                     issue=issue,
                     issue_body=formatter(issue=issue),
-                    has_tracker=self._config.has_option('sut.' + issue['sut'], 'tracker'),
+                    has_tracker=self._config.has_option(f'sut.{issue["sut"]}', 'tracker'),
                     has_exporter=exporter is not None,
                     exporter_ext=getattr(exporter, 'extension', ''))
 
@@ -113,12 +113,12 @@ class IssueReportUIHandler(BaseUIHandler):
             self.send_error(404)
             return
 
-        tracker = config_get_object(self._config, 'sut.' + issue['sut'], 'tracker')
+        tracker = config_get_object(self._config, f'sut.{issue["sut"]}', 'tracker')
         if not tracker:
             self.send_error(404)
             return
 
-        formatter = config_get_object(self._config, 'sut.' + issue['sut'], 'formatter') or JsonFormatter()
+        formatter = config_get_object(self._config, f'sut.{issue["sut"]}', 'formatter') or JsonFormatter()
         issue_title = formatter.summary(issue=issue)
 
         duplicates = []
@@ -153,7 +153,7 @@ class ConfigUIHandler(BaseUIHandler):
             self.send_error(404)
             return
 
-        config_src = markdown('```ini\n%s\n```' % config['src'], extensions=['extra', 'fenced_code', 'codehilite'])
+        config_src = markdown(f'```ini\n{config["src"]}\n```', extensions=['extra', 'fenced_code', 'codehilite'])
         self.render('config.html', subconfig=subconfig, issue_oid=issue_oid, data=data, config_src=config_src)
 
 
@@ -181,7 +181,7 @@ class StaticResourceHandler(RequestHandler):
         # NOTE: The argument must be called path to ensure compatibility with StaticFileHandler.
         # The application's static_path setting is passed to static_handler_class as path.
         self.package = package
-        self.resource_prefix = path if path.endswith('/') else path + '/'
+        self.resource_prefix = path if path.endswith('/') else f'{path}/'
 
     def get(self, path):
         resource_path = urljoin(self.resource_prefix, path)
@@ -217,7 +217,7 @@ class ResourceLoader(BaseLoader):
     def __init__(self, package, resource_prefix, **kwargs):
         super().__init__(**kwargs)
         self.package = package
-        self.resource_prefix = resource_prefix if resource_prefix.endswith('/') else resource_prefix + '/'
+        self.resource_prefix = resource_prefix if resource_prefix.endswith('/') else f'{resource_prefix}/'
         self.package_prefix = urlunparse(('', self.package, self.resource_prefix, '', '', ''))
 
     def resolve_path(self, name, parent_path=None):
@@ -252,7 +252,7 @@ class ResourceLoader(BaseLoader):
         """
         parts = urlparse(name)
         if parts.scheme != '' or parts.params != '' or parts.query != '' or parts.fragment != '':
-            raise ValueError('invalid template path: %s' % name)
+            raise ValueError(f'invalid template path: {name}')
 
         if parts.netloc == '' and parts.path.startswith('/'):
             logger.debug('loading template file: name=%s, path=%s', name, parts.path)
@@ -266,7 +266,7 @@ class ResourceLoader(BaseLoader):
             else:
                 assert not parts.path.startswith('/')
                 package = self.package
-                resource = self.resource_prefix + parts.path
+                resource = f'{self.resource_prefix}{parts.path}'
             logger.debug('loading template resource: name=%s, package=%s, resource=%s', name, package, resource)
             data = pkgutil.get_data(package, resource)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,17 +14,18 @@ classifiers =
     # Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Testing
 
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
     chardet<4  # FIXME: <4 is not a direct constraint but required by requests
     chevron

--- a/tests/call/test_stdin_subprocess_call.py
+++ b/tests/call/test_stdin_subprocess_call.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -15,12 +15,12 @@ from common_call import linesep, resources_dir
 
 
 @pytest.mark.parametrize('command, cwd, env, no_exit_code, test, exp', [
-    ('%s %s --echo-stdin' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None, None, b'foo', fuzzinator.call.NonIssue({'stdout': 'foo', 'stderr': '', 'exit_code': 0})),
-    ('%s %s --echo-stdin --exit-code 1' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None, None, b'foo', {'stdout': 'foo', 'stderr': '', 'exit_code': 1}),
-    ('%s %s --echo-stdin --to-stderr --exit-code 1' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None, None, b'foo', {'stdout': '', 'stderr': 'foo', 'exit_code': 1}),
-    ('%s %s --echo-stdin --exit-code 1' % (sys.executable, os.path.join('.', 'mock_tool.py')), resources_dir, None, None, b'foo', {'stdout': 'foo', 'stderr': '', 'exit_code': 1}),
-    ('%s %s --print-env BAR --echo-stdin --exit-code 1' % (sys.executable, os.path.join('.', 'mock_tool.py')), resources_dir, '{"BAR": "baz"}', None, b'foo', {'stdout': 'baz' + linesep + 'foo', 'stderr': '', 'exit_code': 1}),
-    ('%s %s --echo-stdin --exit-code 0' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None, 'True', b'foo', {'stdout': 'foo', 'stderr': '', 'exit_code': 0}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --echo-stdin', None, None, None, b'foo', fuzzinator.call.NonIssue({'stdout': 'foo', 'stderr': '', 'exit_code': 0})),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --echo-stdin --exit-code 1', None, None, None, b'foo', {'stdout': 'foo', 'stderr': '', 'exit_code': 1}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --echo-stdin --to-stderr --exit-code 1', None, None, None, b'foo', {'stdout': '', 'stderr': 'foo', 'exit_code': 1}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --echo-stdin --exit-code 1', resources_dir, None, None, b'foo', {'stdout': 'foo', 'stderr': '', 'exit_code': 1}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-env BAR --echo-stdin --exit-code 1', resources_dir, '{"BAR": "baz"}', None, b'foo', {'stdout': f'baz{linesep}foo', 'stderr': '', 'exit_code': 1}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --echo-stdin --exit-code 0', None, None, 'True', b'foo', {'stdout': 'foo', 'stderr': '', 'exit_code': 0}),
     ])
 def test_stdin_subprocess_call(command, cwd, env, no_exit_code, test, exp):
     call = fuzzinator.call.StdinSubprocessCall(command=command, cwd=cwd, env=env, no_exit_code=no_exit_code)

--- a/tests/call/test_stream_monitored_subprocess_call.py
+++ b/tests/call/test_stream_monitored_subprocess_call.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -17,12 +17,12 @@ from common_call import linesep, resources_dir
 @pytest.mark.skipif(not hasattr(fuzzinator.call, 'StreamMonitoredSubprocessCall'),
                     reason='platform-dependent component')
 @pytest.mark.parametrize('command, cwd, env, end_patterns, test, exp', [
-    ('%s %s --print-args 42 {test}' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None, '["(?P<bar>[a-z]+)"]', 'foo', {'stdout': '42' + linesep + 'foo' + linesep, 'stderr': '', 'bar': 'foo'}),
-    ('%s %s --print-args --to-stderr 42 {test}' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None, '["(?P<bar>[a-z]+)"]', 'foo', {'stdout': '', 'stderr': '42' + linesep + 'foo' + linesep, 'bar': 'foo'}),
-    ('%s %s --print-args --exit-code 1 42 {test}' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None, '["(?P<bar>[a-z]+)"]', 'foo', {'stdout': '42' + linesep + 'foo' + linesep, 'stderr': '', 'bar': 'foo'}),
-    ('%s %s --print-args --to-stderr --exit-code 1 42 {test}' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None, '["(?P<bar>[a-z]+)"]', 'foo', {'stdout': '', 'stderr': '42' + linesep + 'foo' + linesep, 'bar': 'foo'}),
-    ('%s %s --print-args --print-env FOO --exit-code 1 42 {test}' % (sys.executable, os.path.join('.', 'mock_tool.py')), resources_dir, '{"FOO": "baz"}', '["(?P<bar>[a-z]+)"]', '42', {'stdout': '42' + linesep + '42' + linesep + 'baz' + linesep, 'stderr': '', 'bar': 'baz'}),
-    ('%s %s --print-args --exit-code 1 42 {test}' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None, '["(?P<bar>[a-z]+)"]', '42', fuzzinator.call.NonIssue({'stderr': '', 'stdout': '42' + linesep + '42' + linesep})),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args 42 {{test}}', None, None, '["(?P<bar>[a-z]+)"]', 'foo', {'stdout': f'42{linesep}foo{linesep}', 'stderr': '', 'bar': 'foo'}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args --to-stderr 42 {{test}}', None, None, '["(?P<bar>[a-z]+)"]', 'foo', {'stdout': '', 'stderr': f'42{linesep}foo{linesep}', 'bar': 'foo'}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args --exit-code 1 42 {{test}}', None, None, '["(?P<bar>[a-z]+)"]', 'foo', {'stdout': f'42{linesep}foo{linesep}', 'stderr': '', 'bar': 'foo'}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args --to-stderr --exit-code 1 42 {{test}}', None, None, '["(?P<bar>[a-z]+)"]', 'foo', {'stdout': '', 'stderr': f'42{linesep}foo{linesep}', 'bar': 'foo'}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args --print-env FOO --exit-code 1 42 {{test}}', resources_dir, '{"FOO": "baz"}', '["(?P<bar>[a-z]+)"]', '42', {'stdout': f'42{linesep}42{linesep}baz{linesep}', 'stderr': '', 'bar': 'baz'}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args --exit-code 1 42 {{test}}', None, None, '["(?P<bar>[a-z]+)"]', '42', fuzzinator.call.NonIssue({'stderr': '', 'stdout': f'42{linesep}42{linesep}'})),
 ])
 def test_stream_monitored_subprocess_call(command, cwd, env, end_patterns, test, exp):
     call = fuzzinator.call.StreamMonitoredSubprocessCall(command=command, cwd=cwd, env=env, end_patterns=end_patterns)

--- a/tests/call/test_subprocess_call.py
+++ b/tests/call/test_subprocess_call.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -15,12 +15,12 @@ from common_call import linesep, resources_dir
 
 
 @pytest.mark.parametrize('command, cwd, env, no_exit_code, test, exp', [
-    ('%s %s --print-args {test}' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None, None, 'foo', fuzzinator.call.NonIssue({'stdout': 'foo' + linesep, 'stderr': '', 'exit_code': 0})),
-    ('%s %s --print-args --exit-code 1 {test}' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None, None, 'foo', {'stdout': 'foo' + linesep, 'stderr': '', 'exit_code': 1}),
-    ('%s %s --print-args --to-stderr --exit-code 1 {test}' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None, None, 'foo', {'stdout': '', 'stderr': 'foo' + linesep, 'exit_code': 1}),
-    ('%s %s --print-args --exit-code 1 {test}' % (sys.executable, os.path.join('.', 'mock_tool.py')), resources_dir, None, None, 'foo', {'stdout': 'foo' + linesep, 'stderr': '', 'exit_code': 1}),
-    ('%s %s --print-env BAR --print-args --exit-code 1 {test}' % (sys.executable, os.path.join('.', 'mock_tool.py')), resources_dir, '{"BAR": "baz"}', None, 'foo', {'stdout': 'foo' + linesep + 'baz' + linesep, 'stderr': '', 'exit_code': 1}),
-    ('%s %s --print-args --exit-code 0 {test}' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None, 'True', 'foo', {'stdout': 'foo' + linesep, 'stderr': '', 'exit_code': 0}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args {{test}}', None, None, None, 'foo', fuzzinator.call.NonIssue({'stdout': f'foo{linesep}', 'stderr': '', 'exit_code': 0})),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args --exit-code 1 {{test}}', None, None, None, 'foo', {'stdout': f'foo{linesep}', 'stderr': '', 'exit_code': 1}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args --to-stderr --exit-code 1 {{test}}', None, None, None, 'foo', {'stdout': '', 'stderr': f'foo{linesep}', 'exit_code': 1}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args --exit-code 1 {{test}}', resources_dir, None, None, 'foo', {'stdout': f'foo{linesep}', 'stderr': '', 'exit_code': 1}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-env BAR --print-args --exit-code 1 {{test}}', resources_dir, '{"BAR": "baz"}', None, 'foo', {'stdout': f'foo{linesep}baz{linesep}', 'stderr': '', 'exit_code': 1}),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args --exit-code 0 {{test}}', None, None, 'True', 'foo', {'stdout': f'foo{linesep}', 'stderr': '', 'exit_code': 0}),
 ])
 def test_subprocess_call(command, cwd, env, no_exit_code, test, exp):
     call = fuzzinator.call.SubprocessCall(command=command, cwd=cwd, env=env, no_exit_code=no_exit_code)

--- a/tests/call/test_subprocess_property_decorator.py
+++ b/tests/call/test_subprocess_property_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -18,11 +18,11 @@ from common_call import linesep, resources_dir, MockAlwaysFailCall, MockNeverFai
     ({'init_foo': 'init_bar'}, {'test': 'bar'})
 ])
 @pytest.mark.parametrize('call_class, dec_kwargs, exp', [
-    (MockAlwaysFailCall, {'property': 'baz', 'command': '%s %s --print-args qux' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py'))}, {'init_foo': 'init_bar', 'test': 'bar', 'baz': 'qux' + linesep}),
-    (MockAlwaysFailCall, {'property': 'baz', 'command': '%s %s --print-args qux' % (sys.executable, os.path.join('.', 'mock_tool.py')), 'cwd': resources_dir}, {'init_foo': 'init_bar', 'test': 'bar', 'baz': 'qux' + linesep}),
-    (MockAlwaysFailCall, {'property': 'baz', 'command': '%s %s --print-env QUX' % (sys.executable, os.path.join('.', 'mock_tool.py')), 'cwd': resources_dir, 'env': '{"QUX": "qux"}'}, {'init_foo': 'init_bar', 'test': 'bar', 'baz': 'qux' + linesep}),
+    (MockAlwaysFailCall, {'property': 'baz', 'command': f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args qux'}, {'init_foo': 'init_bar', 'test': 'bar', 'baz': f'qux{linesep}'}),
+    (MockAlwaysFailCall, {'property': 'baz', 'command': f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args qux', 'cwd': resources_dir}, {'init_foo': 'init_bar', 'test': 'bar', 'baz': f'qux{linesep}'}),
+    (MockAlwaysFailCall, {'property': 'baz', 'command': f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-env QUX', 'cwd': resources_dir, 'env': '{"QUX": "qux"}'}, {'init_foo': 'init_bar', 'test': 'bar', 'baz': f'qux{linesep}'}),
 
-    (MockNeverFailCall, {'property': 'baz', 'command': '%s %s --print-env QUX' % (sys.executable, os.path.join('.', 'mock_tool.py')), 'cwd': resources_dir, 'env': '{"QUX": "qux"}'}, None),
+    (MockNeverFailCall, {'property': 'baz', 'command': f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-env QUX', 'cwd': resources_dir, 'env': '{"QUX": "qux"}'}, None),
 ])
 def test_subprocess_property_decorator(call_class, call_init_kwargs, call_kwargs, dec_kwargs, exp):
     call_class = fuzzinator.call.SubprocessPropertyDecorator(**dec_kwargs)(call_class)

--- a/tests/fuzzer/test_subprocess_runner.py
+++ b/tests/fuzzer/test_subprocess_runner.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -16,12 +16,12 @@ from common_fuzzer import blinesep, resources_dir
 
 
 @pytest.mark.parametrize('command, cwd, env, contents, exp', [
-    ('%s %s -i %s -o {work_dir}' % (sys.executable, join(resources_dir, 'mock_fuzzer.py'), join(resources_dir, 'mock_tests')), None, None, True, {b'foo' + blinesep, b'bar' + blinesep, b'baz' + blinesep}),
-    ('%s %s -i %s -o .' % (sys.executable, join(resources_dir, 'mock_fuzzer.py'), join(resources_dir, 'mock_tests')), '{work_dir}', None, True, {b'foo' + blinesep, b'bar' + blinesep, b'baz' + blinesep}),
-    ('%s %s -i %s -o {work_dir}' % (sys.executable, join('.', 'mock_fuzzer.py'), 'mock_tests'), resources_dir, None, True, {b'foo' + blinesep, b'bar' + blinesep, b'baz' + blinesep}),
-    ('%s %s -i %s' % (sys.executable, join('.', 'mock_fuzzer.py'), 'mock_tests'), resources_dir, '{"ODIR": "{work_dir}"}', True, {b'foo' + blinesep, b'bar' + blinesep, b'baz' + blinesep}),
-    ('%s %s -o {work_dir}' % (sys.executable, join('.', 'mock_fuzzer.py')), resources_dir, '{"IDIR": "mock_tests"}', True, {b'foo' + blinesep, b'bar' + blinesep, b'baz' + blinesep}),
-    ('%s %s -i %s -o {work_dir}' % (sys.executable, join('.', 'mock_fuzzer.py'), 'mock_tests'), resources_dir, None, False, {join('{tmpdir}', 'foo.txt'), join('{tmpdir}', 'bar.txt'), join('{tmpdir}', 'baz.txt')}),
+    (f'{sys.executable} {join(resources_dir, "mock_fuzzer.py")} -i {join(resources_dir, "mock_tests")} -o {{work_dir}}', None, None, True, {b'foo' + blinesep, b'bar' + blinesep, b'baz' + blinesep}),
+    (f'{sys.executable} {join(resources_dir, "mock_fuzzer.py")} -i {join(resources_dir, "mock_tests")} -o .', '{work_dir}', None, True, {b'foo' + blinesep, b'bar' + blinesep, b'baz' + blinesep}),
+    (f'{sys.executable} {join(resources_dir, "mock_fuzzer.py")} -i {join(resources_dir, "mock_tests")} -o {{work_dir}}', resources_dir, None, True, {b'foo' + blinesep, b'bar' + blinesep, b'baz' + blinesep}),
+    (f'{sys.executable} {join(resources_dir, "mock_fuzzer.py")} -i mock_tests', resources_dir, '{"ODIR": "{work_dir}"}', True, {b'foo' + blinesep, b'bar' + blinesep, b'baz' + blinesep}),
+    (f'{sys.executable} {join(resources_dir, "mock_fuzzer.py")} -o {{work_dir}}', resources_dir, '{"IDIR": "mock_tests"}', True, {b'foo' + blinesep, b'bar' + blinesep, b'baz' + blinesep}),
+    (f'{sys.executable} {join(resources_dir, "mock_fuzzer.py")} -i mock_tests -o {{work_dir}}', resources_dir, None, False, {join('{tmpdir}', 'foo.txt'), join('{tmpdir}', 'bar.txt'), join('{tmpdir}', 'baz.txt')}),
 ])
 def test_subprocess_runner(command, cwd, env, contents, exp, tmpdir):
     fuzzer = fuzzinator.fuzzer.SubprocessRunner(command=command, cwd=cwd, env=env, contents=contents, work_dir=str(tmpdir))

--- a/tests/update/test_subprocess_update.py
+++ b/tests/update/test_subprocess_update.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -15,9 +15,9 @@ from common_update import resources_dir
 
 
 @pytest.mark.parametrize('command, cwd, env', [
-    ('%s %s --print-args foo ' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None),
-    ('%s %s --print-args --to-stderr --exit-code 1 foo' % (sys.executable, os.path.join(resources_dir, 'mock_tool.py')), None, None),
-    ('%s %s --print-env FOO' % (sys.executable, os.path.join('.', 'mock_tool.py')), resources_dir, '{"FOO": "baz"}'),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args foo ', None, None),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-args --to-stderr --exit-code 1 foo', None, None),
+    (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-env FOO', resources_dir, '{"FOO": "baz"}'),
 ])
 def test_subprocess_update(command, cwd, env):
     fuzzinator.update.SubprocessUpdate(command=command, cwd=cwd, env=env)()


### PR DESCRIPTION
Python3.5 has reached the end of its lifetime two years ago, hence Fuzzinator also stops supporting it. The patch introduces the usage of f-strings - supported from Python3.6 - and unifies string representations to use it where possible.
It also enables the 'consider-using-f-string' pylint checker.