### PR TITLE
Fix pylint issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -17,6 +17,7 @@ extension-pkg-allow-list=fcntl, math, select
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
+    useless-option-value,
     line-too-long, fixme, missing-docstring, invalid-name, no-self-use, unused-argument,
     wildcard-import, unused-wildcard-import, ungrouped-imports,
     too-many-arguments, too-many-locals,

--- a/fuzzinator/config.py
+++ b/fuzzinator/config.py
@@ -150,7 +150,7 @@ def config_get_fuzzers(config):
         config_str = StringIO()
         sub_parser.write(config_str, space_around_delimiters=False)
         src = config_str.getvalue()
-        fuzzers[fuzzer] = dict(sut=sut, subconfig=hashlib.md5(src.encode('utf-8', errors='ignore')).hexdigest()[:9], src=src)
+        fuzzers[fuzzer] = {'sut': sut, 'subconfig': hashlib.md5(src.encode('utf-8', errors='ignore')).hexdigest()[:9], 'src': src}
 
     return fuzzers
 

--- a/fuzzinator/controller.py
+++ b/fuzzinator/controller.py
@@ -236,7 +236,7 @@ class Controller(object):
 
         self.listener = ListenerManager()
         for name in config_get_kwargs(self.config, 'listeners'):
-            self.listener += config_get_object(self.config, 'listeners', name, init_kwargs=dict(config=config))
+            self.listener += config_get_object(self.config, 'listeners', name, init_kwargs={'config': config})
 
         self._shared_queue = Queue()
         self._shared_lock = Lock()
@@ -403,7 +403,7 @@ class Controller(object):
                     continue
 
                 proc = Process(target=self._run_job, args=(next_job,))
-                running_jobs[next_job.id] = dict(job=next_job, proc=proc)
+                running_jobs[next_job.id] = {'job': next_job, 'proc': proc}
                 self.listener.on_job_activated(job_id=next_job.id)
                 proc.start()
 
@@ -429,7 +429,7 @@ class Controller(object):
         # Added for the sake of completeness and consistency.
         # Should not be used by UI to add fuzz jobs.
         with self._shared_lock:
-            self._shared_queue.put((FuzzJob, dict(fuzzer_name=fuzzer_name, subconfig_id=self.fuzzers[fuzzer_name]['subconfig']), priority))
+            self._shared_queue.put((FuzzJob, {'fuzzer_name': fuzzer_name, 'subconfig_id': self.fuzzers[fuzzer_name]['subconfig']}, priority))
         return True
 
     def add_validate_job(self, issue, priority=False):
@@ -437,7 +437,7 @@ class Controller(object):
             return False
 
         with self._shared_lock:
-            self._shared_queue.put((ValidateJob, dict(issue=issue), priority))
+            self._shared_queue.put((ValidateJob, {'issue': issue}, priority))
         return True
 
     def add_reduce_job(self, issue, priority=False):
@@ -445,7 +445,7 @@ class Controller(object):
             return False
 
         with self._shared_lock:
-            self._shared_queue.put((ReduceJob, dict(issue=issue), priority))
+            self._shared_queue.put((ReduceJob, {'issue': issue}, priority))
         return True
 
     def add_update_job(self, sut_name, priority=False):
@@ -453,7 +453,7 @@ class Controller(object):
             return False
 
         with self._shared_lock:
-            self._shared_queue.put((UpdateJob, dict(sut_name=sut_name), priority))
+            self._shared_queue.put((UpdateJob, {'sut_name': sut_name}, priority))
 
         if as_bool(self.config.get(f'sut.{sut_name}', 'validate_after_update', fallback=self.validate_after_update)):
             self.validate_all(sut_name)
@@ -474,7 +474,7 @@ class Controller(object):
 
     def cancel_job(self, job_id):
         with self._shared_lock:
-            self._shared_queue.put((None, dict(job_id=job_id), None))
+            self._shared_queue.put((None, {'job_id': job_id}, None))
         return True
 
     @staticmethod

--- a/fuzzinator/job/call_job.py
+++ b/fuzzinator/job/call_job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -28,7 +28,7 @@ class CallJob(object):
         # Save issue details.
         issue.update(sut=self.sut_name,
                      fuzzer=self.fuzzer_name,
-                     subconfig=dict(subconfig=self.subconfig_id),
+                     subconfig={'subconfig': self.subconfig_id},
                      test=test,
                      reduced=None,
                      reported=False)

--- a/fuzzinator/mongo_driver.py
+++ b/fuzzinator/mongo_driver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 # Copyright (c) 2019 Tamas Keri.
 #
 # Licensed under the BSD 3-Clause License
@@ -79,8 +79,8 @@ class MongoDriver(object):
             result = self._db.fuzzinator_issues.find_one_and_update(
                 {'sut': issue['sut'], 'id': issue['id'], 'invalid': invalid or {'$exists': False}},
                 {'$setOnInsert': dict(issue, first_seen=first_seen),
-                 '$max': dict(last_seen=last_seen),
-                 '$inc': dict(count=1)},
+                 '$max': {'last_seen': last_seen},
+                 '$inc': {'count': 1}},
                 upsert=True,
                 return_document=ReturnDocument.AFTER,
             )
@@ -88,7 +88,7 @@ class MongoDriver(object):
             if count:
                 result = self._db.fuzzinator_issues.find_one_and_update(
                     {'sut': issue['sut'], 'id': issue['id'], 'invalid': invalid or {'$exists': False}},
-                    {'$max': dict(count=count)},
+                    {'$max': {'count': count}},
                     return_document=ReturnDocument.AFTER,
                 )
 

--- a/fuzzinator/reduce/picire_common.py
+++ b/fuzzinator/reduce/picire_common.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -75,18 +75,18 @@ class PicireReducer(Reducer):
         # Choose the reducer class that will be used and its configuration.
         if not parallel:
             self.reduce_class = picire.DD
-            self.reduce_config = dict(subset_iterator=subset_iterator,
-                                      complement_iterator=complement_iterator,
-                                      subset_first=subset_first)
+            self.reduce_config = {'subset_iterator': subset_iterator,
+                                  'complement_iterator': complement_iterator,
+                                  'subset_first': subset_first}
         else:
             if combine_loops:
                 self.reduce_class = picire.CombinedParallelDD
-                self.reduce_config = dict(config_iterator=picire.CombinedIterator(subset_first, subset_iterator, complement_iterator))
+                self.reduce_config = {'config_iterator': picire.CombinedIterator(subset_first, subset_iterator, complement_iterator)}
             else:
                 self.reduce_class = picire.ParallelDD
-                self.reduce_config = dict(subset_iterator=subset_iterator,
-                                          complement_iterator=complement_iterator,
-                                          subset_first=subset_first)
+                self.reduce_config = {'subset_iterator': subset_iterator,
+                                      'complement_iterator': complement_iterator,
+                                      'subset_first': subset_first}
             self.reduce_config.update(proc_num=jobs,
                                       max_utilization=max_utilization)
         self.reduce_config.update(split=split_class(n=granularity))
@@ -103,11 +103,11 @@ class PicireReducer(Reducer):
             encoding = self.encoding or 'latin-1'
 
         new_issues = {}
-        tester_config = dict(sut_call=sut_call,
-                             issue=issue,
-                             on_job_progressed=on_job_progressed,
-                             filename=issue.get('filename', 'test'),
-                             encoding=encoding,
-                             new_issues=new_issues)
+        tester_config = {'sut_call': sut_call,
+                         'issue': issue,
+                         'on_job_progressed': on_job_progressed,
+                         'filename': issue.get('filename', 'test'),
+                         'encoding': encoding,
+                         'new_issues': new_issues}
 
         return self.TestTuple(src, encoding), self.TesterTuple(PicireTester, tester_config, new_issues)

--- a/fuzzinator/tracker/bugzilla_tracker.py
+++ b/fuzzinator/tracker/bugzilla_tracker.py
@@ -89,6 +89,6 @@ class BugzillaTracker(Tracker):
 
     def settings(self):
         products = self.bzapi.getproducts(ptype='selectable')
-        return {product['name']: dict(components=self.bzapi.getcomponents(product['name']),
-                                      versions=[version['name'] for version in product['versions'] if version['is_active']])
+        return {product['name']: {'components': self.bzapi.getcomponents(product['name']),
+                                  'versions': [version['name'] for version in product['versions'] if version['is_active']]}
                 for product in products if product['components']}

--- a/fuzzinator/tracker/gitlab_tracker.py
+++ b/fuzzinator/tracker/gitlab_tracker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2019-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -52,7 +52,7 @@ class GitlabTracker(Tracker):
 
     def report_issue(self, *, title, body):
         try:
-            new_issue = self.project.issues.create(dict(title=title, description=body))
+            new_issue = self.project.issues.create({'title': title, 'description': body})
             return new_issue.attributes['web_url']
         except (exceptions.GitlabAuthenticationError, exceptions.GitlabCreateError) as e:
             raise TrackerError('Issue reporting failed') from e

--- a/fuzzinator/tracker/monorail_tracker.py
+++ b/fuzzinator/tracker/monorail_tracker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -69,11 +69,11 @@ class MonorailTracker(Tracker):
     def report_issue(self, *, title, body):
         try:
             new_issue = self.monorail.issues().insert(projectId=self.project_id,
-                                                      body=dict(summary=title,
-                                                                labels=self.labels,
-                                                                status=self.status,
-                                                                projectId=self.project_id,
-                                                                description=body)).execute()
+                                                      body={'summary': title,
+                                                            'labels': self.labels,
+                                                            'status': self.status,
+                                                            'projectId': self.project_id,
+                                                            'description': body}).execute()
             return self.weburl_template.format(project_id=self.project_id, issue_id=new_issue['id'])
         except Exception as e:
             raise TrackerError('Issue reporting failed') from e

--- a/fuzzinator/ui/tui/dialogs.py
+++ b/fuzzinator/ui/tui/dialogs.py
@@ -24,9 +24,9 @@ class Dialog(PopUpTarget):
 
     def __init__(self, title, body, footer_btns, warning=False):
         if not warning:
-            style = dict(body='dialog', title='dialog_title', border='dialog_border')
+            style = {'body': 'dialog', 'title': 'dialog_title', 'border': 'dialog_border'}
         else:
-            style = dict(body='warning', title='warning_title', border='warning_border')
+            style = {'body': 'warning', 'title': 'warning_title', 'border': 'warning_border'}
 
         self.walker = SimpleListWalker(body)
         self.listbox = ListBox(self.walker)

--- a/fuzzinator/ui/tui/popup_buttons.py
+++ b/fuzzinator/ui/tui/popup_buttons.py
@@ -34,10 +34,10 @@ class AboutButton(PopUpLauncher):
         width = max(len(line) for line in self.about.content.splitlines()) + 10
         height = self.about.content.count('\n') + 4
         cols, rows = get_terminal_size()
-        return dict(left=max(cols // 2 - width // 2, 1),
-                    top=min(-rows // 2 - height // 2, -1),
-                    overlay_width=width,
-                    overlay_height=height)
+        return {'left': max(cols // 2 - width // 2, 1),
+                'top': min(-rows // 2 - height // 2, -1),
+                'overlay_width': width,
+                'overlay_height': height}
 
     def create_pop_up(self):
         connect_signal(self.about, 'close', lambda button: self.close_pop_up())

--- a/fuzzinator/ui/tui/reporter_dialogs.py
+++ b/fuzzinator/ui/tui/reporter_dialogs.py
@@ -151,8 +151,8 @@ class ReportDialog(PopUpTarget):
         :return: the data to be reported to the issue tracker.
         :rtype: dict
         """
-        return dict(title=self.issue_title.edit_text,
-                    body=self.issue_desc.edit_text)
+        return {'title': self.issue_title.edit_text,
+                'body': self.issue_desc.edit_text}
 
 
 class BugzillaReportDialog(ReportDialog):

--- a/fuzzinator/ui/tui/table.py
+++ b/fuzzinator/ui/tui/table.py
@@ -310,7 +310,7 @@ class TableRow(WidgetWrap):
         elif isinstance(table.border, int):
             border_width = table.border
         else:
-            raise Exception(f'Invalid border specification: {table.border}')
+            raise ValueError(f'Invalid border specification: {table.border}')
 
         self.row = self.column_class(self.contents)
         if self.header:
@@ -618,7 +618,7 @@ class Table(WidgetWrap):
             sort_field = self.columns[index // 2].name
 
         if not isinstance(index, int):
-            raise Exception(f'invalid column index: {index}')
+            raise ValueError(f'invalid column index: {index}')
 
         if reverse is not None:
             self.sort_reverse = reverse ^ self.columns[index // 2].sort_reverse

--- a/fuzzinator/ui/tui/widgets.py
+++ b/fuzzinator/ui/tui/widgets.py
@@ -81,10 +81,10 @@ class MainWindow(PopUpLauncher):
         width = max(max(len(line) for line in msg.splitlines()), 20)
         height = msg.count('\n') + 4
         cols, rows = os.get_terminal_size()
-        self.pop_up_params = dict(left=max(cols // 2 - width // 2, 1),
-                                  top=max(rows // 2 - height // 2, 1),
-                                  overlay_width=width,
-                                  overlay_height=height)
+        self.pop_up_params = {'left': max(cols // 2 - width // 2, 1),
+                              'top': max(rows // 2 - height // 2, 1),
+                              'overlay_width': width,
+                              'overlay_height': height}
         return self.open_pop_up()
 
     def warning_popup(self, msg):
@@ -358,16 +358,16 @@ class JobsTable(WidgetWrap):
             self.listbox.focus_position = 0
 
     def on_fuzz_job_added(self, job_id, fuzzer, sut, cost, batch):
-        self.insert_widget(job_id, FuzzerJobWidget(dict(fuzzer=fuzzer, sut=sut, cost=cost), pb_done=batch))
+        self.insert_widget(job_id, FuzzerJobWidget({'fuzzer': fuzzer, 'sut': sut, 'cost': cost}, pb_done=batch))
 
     def on_reduce_job_added(self, job_id, sut, cost, issue_id, size):
-        self.insert_widget(job_id, ReduceJobWidget(dict(sut=sut, cost=cost, issue=issue_id), pb_done=size))
+        self.insert_widget(job_id, ReduceJobWidget({'sut': sut, 'cost': cost, 'issue': issue_id}, pb_done=size))
 
     def on_update_job_added(self, job_id, sut):
-        self.insert_widget(job_id, UpdateJobWidget(dict(sut=sut)))
+        self.insert_widget(job_id, UpdateJobWidget({'sut': sut}))
 
     def on_validate_job_added(self, job_id, sut, issue_id):
-        self.insert_widget(job_id, ValidateJobWidget(dict(sut=sut, issue=issue_id)))
+        self.insert_widget(job_id, ValidateJobWidget({'sut': sut, 'issue': issue_id}))
 
     def on_job_activated(self, job_id):
         idx = self.walker.index(self.jobs[job_id])
@@ -483,7 +483,7 @@ class JobWidget(WidgetWrap):
 
 class FuzzerJobWidget(JobWidget):
 
-    labels = dict(fuzzer='Fuzzer', sut='Sut', cost='Cost')
+    labels = {'fuzzer': 'Fuzzer', 'sut': 'Sut', 'cost': 'Cost'}
     title = 'Fuzzer Job'
 
     def __init__(self, data, pb_done):
@@ -492,7 +492,7 @@ class FuzzerJobWidget(JobWidget):
 
 class ReduceJobWidget(JobWidget):
 
-    labels = dict(sut='Sut', cost='Cost', issue='Issue')
+    labels = {'sut': 'Sut', 'cost': 'Cost', 'issue': 'Issue'}
     title = 'Reduce Job'
     height = 8
 
@@ -503,13 +503,13 @@ class ReduceJobWidget(JobWidget):
 
 class UpdateJobWidget(JobWidget):
 
-    labels = dict(sut='Sut')
+    labels = {'sut': 'Sut'}
     title = 'Update Job'
 
 
 class ValidateJobWidget(JobWidget):
 
-    labels = dict(sut='Sut', issue='Issue')
+    labels = {'sut': 'Sut', 'issue': 'Issue'}
     title = 'Validate Job'
 
 
@@ -565,7 +565,7 @@ class TimerWidget(Text):
         r = ss - hh * 3600
         mm = r // 60
         # truncate to first digit after decimal
-        ss = (r - mm * 60)
+        ss = r - mm * 60
         return f'{hh:02.0f}:{mm:02.0f}:{ss:04.1f}'
 
     def update(self):

--- a/fuzzinator/ui/wui/api_handlers.py
+++ b/fuzzinator/ui/wui/api_handlers.py
@@ -79,14 +79,14 @@ class BaseAPIHandler(RequestHandler):
         detailed = self.get_query_argument('detailed', None)
         show_all = self.get_query_argument('showAll', None) in ('true', 'True', '1')
 
-        return dict(
-            filter={'$or': [{c: {'$regex': search, '$options': 'i'}} for c in columns]} if search else None,
-            skip=int(offset) if offset else 0,
-            limit=int(limit) if limit else None,
-            sort={sort: {'asc': ASCENDING, 'desc': DESCENDING}[order]} if sort and order else None,
-            detailed=detailed in ('true', 'True', '1') if detailed else True,
-            session_start=None if show_all else self._controller.session_start,
-        )
+        return {
+            'filter': {'$or': [{c: {'$regex': search, '$options': 'i'}} for c in columns]} if search else None,
+            'skip': int(offset) if offset else 0,
+            'limit': int(limit) if limit else None,
+            'sort': {sort: {'asc': ASCENDING, 'desc': DESCENDING}[order]} if sort and order else None,
+            'detailed': detailed in ('true', 'True', '1') if detailed else True,
+            'session_start': None if show_all else self._controller.session_start,
+        }
 
     def load_mime(self, mime):
         if mime in self.loads:

--- a/fuzzinator/ui/wui/wui.py
+++ b/fuzzinator/ui/wui/wui.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2019 Tamas Keri.
-# Copyright (c) 2019-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2019-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -36,7 +36,7 @@ class Wui(object):
         self.controller = controller
         self.controller.listener += WuiListener(self.events, self.lock)
         # Collection of request handlers that make up a web application.
-        handler_args = dict(wui=self)
+        handler_args = {'wui': self}
         self.app = web.Application([(r'/', IssuesUIHandler, handler_args),
                                     (r'/issues/([0-9a-f]{24})', IssueUIHandler, handler_args),
                                     (r'/issues/([0-9a-f]{24})/report', IssueReportUIHandler, handler_args),
@@ -52,7 +52,7 @@ class Wui(object):
                                     (r'/api/.*', NotFoundAPIHandler)],
                                    default_handler_class=NotFoundHandler, default_handler_args=handler_args,
                                    template_loader=ResourceLoader(__package__, 'resources/templates'),
-                                   static_handler_class=StaticResourceHandler, static_handler_args=dict(package=__package__), static_path='resources/static',
+                                   static_handler_class=StaticResourceHandler, static_handler_args={'package': __package__}, static_path='resources/static',
                                    autoreload=False, debug=debug)
         # Starts an HTTP server for this application on the given port.
         if cert:


### PR DESCRIPTION
- `no-self-use` and `bad-whitespace` warnings had to be disabled previously for pylint. But recent pylint does not check for them anymore, and so listing it as disabled causes a warning. As both older and newer pylint versions are to be supported, the new warning is also disabled.
- Adapted to code to fix `use-dict-literal`, `superfluous-parens` and `broad-exception-raised` pylint errors.
- Adapted the documentation of EmailListener to fix an unexpected unindentation issue.