### PR TITLE
Remove custom Sphinx extension to add API entries to ToC

### DIFF
--- a/docs/_ext/fuzzinator_sphinx.py
+++ b/docs/_ext/fuzzinator_sphinx.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2020-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -8,32 +8,6 @@
 from docutils import nodes
 from docutils.transforms import Transform
 from sphinx import addnodes
-
-
-# Add section header above all top-level classes and functions in
-# autodoc-generated documentation to make them appear in TOC.
-class AddApiToToc(Transform):
-    default_priority = 50
-    def apply(self):
-        # desc nodes of sphinx represent domain-specific entities,
-        # their first children, desc_signature nodes, are their "heads"
-        for signode in self.document.traverse(addnodes.desc_signature):
-            descnode = signode.parent
-            domain = descnode['domain']
-            objtype = descnode['objtype']
-            # only interested in py:class and py:function entities
-            if domain != 'py' or objtype not in ['class', 'exception', 'function']:
-                continue
-
-            # wrap the desc node in a section node, which will appear in TOC
-            name = signode['fullname']
-            secname = objtype + ' ' + name
-            _ = ''
-            secnode = nodes.section(_, nodes.title(_, objtype + ' ', nodes.literal(_, name)),
-                                    ids=[nodes.make_id(secname)],
-                                    names=[nodes.fully_normalize_name(secname)])
-            descnode.replace_self(secnode)
-            secnode += descnode
 
 
 # Useful for README.rst that is also included by docs/introduction.rst but
@@ -64,7 +38,6 @@ class FixOuterDocLinks(Transform):
 
 
 def setup(app):
-    app.add_transform(AddApiToToc)
     app.add_transform(FixOuterDocLinks)
 
     return {

--- a/docs/fuzzinator.tracker.rst
+++ b/docs/fuzzinator.tracker.rst
@@ -15,12 +15,9 @@ UI Extensions
 .. autoclass:: fuzzinator.ui.tui.ReportDialog
    :members:
 
-.. _template-report.html:
+.. _template-report:
 
-template ``report.html``
-------------------------
-
-.. describe:: report.html
+.. describe:: template report.html
 
     Parent template of pages that allow preparing an issue report on the
     Tornado_-based web UI. To be extended using ``{% extends "report.html" %}``.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx>=5.2
 sphinx_rtd_theme
 sphinxcontrib-runcmd

--- a/fuzzinator/tracker/tracker.py
+++ b/fuzzinator/tracker/tracker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -39,9 +39,9 @@ class Tracker(metaclass=Multiton):
     If it contains the key ``'wui'``, then the associated value must either be
     an absolute file path (formatted as ``/path/to/file``) or a reference to a
     resource in a package (formatted as ``//package.module/path/to/file``),
-    naming a child template of :ref:`template-report.html`. That specialized
-    template page will be used by the web UI to prepare the report of an issue
-    with this tracker.
+    naming a child template of :ref:`report.html <template-report>`. That
+    specialized template page will be used by the web UI to prepare the report
+    of an issue with this tracker.
 
     See :ref:`ui-extensions`.
     """
@@ -86,7 +86,7 @@ class Tracker(metaclass=Multiton):
         collect input from the user that will be passed to the extra arguments
         (see: :attr:`ui_extension`, and
         :meth:`fuzzinator.ui.tui.ReportDialog.data` or
-        :ref:`template-report.html`).
+        :ref:`report.html <template-report>`).
         """
         raise NotImplementedError()
 
@@ -97,7 +97,7 @@ class Tracker(metaclass=Multiton):
         when reporting an issue and need some tracker-specific information to
         build the UI extension (see :attr:`ui_extension`, and
         :meth:`fuzzinator.ui.tui.ReportDialog.init`
-        or :ref:`template-report.html`).
+        or :ref:`report.html <template-report>`).
 
         Return ``None`` by default.
 


### PR DESCRIPTION
Sphinx has this feature since 5.2 and it is enabled by default. Now, switching to the official approach. Also adapting some docs to the new style.