### PR TITLE
Update setup-node action to v3 and Node to 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,9 +54,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 16
       - run: pip install --upgrade tox
       - run: tox -v -e eslint
 


### PR DESCRIPTION
Actions running on Node 12 are deprecated and setup-node@v1 is raising a warning.