### PR TITLE
Drop support of Python 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,18 +6,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.9']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.9']
         exclude:
           # NOTE: pynacl should not be built from sdist, but it has no binary
           # wheel available for windows+pypy
           - os: windows-latest
             python-version: 'pypy-3.9'
-          # Python3.6 is only available in GH Actions up to Ubuntu 20.04.
-          - os: ubuntu-latest
-            python-version: '3.6'
-        include:
-          - os: ubuntu-20.04
-            python-version: '3.6'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ interfaces:
 Requirements
 ============
 
-* Python_ >= 3.6
+* Python_ >= 3.7
 * MongoDB_ >= 3.6 (either local installation or access to remote database)
 * Java_ SE >= 7 JRE or JDK (optional, required if the *Picireny* test case
   reducer is used)

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     # Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -25,7 +24,7 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     chardet<4  # FIXME: <4 is not a direct constraint but required by requests
     chevron


### PR DESCRIPTION
Python 3.6 has reached the end of its lifetime more than a year ago.