### PR TITLE
Update roles from func to class where outdated

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -35,8 +35,8 @@ Minimum Configuration
 =====================
 
 Let's start with the *minimum configuration* example that defines one SUT with
-:func:`fuzzinator.call.StdinSubprocessCall`, expecting input from *stdin* and
-one test generator with :func:`fuzzinator.fuzzer.RandomContent` that simply
+:class:`fuzzinator.call.StdinSubprocessCall`, expecting input from *stdin* and
+one test generator with :class:`fuzzinator.fuzzer.RandomContent` that simply
 produces random strings.
 
 .. literalinclude:: ../examples/configs/jerry_minimal.ini

--- a/fuzzinator/call/stream_monitored_subprocess_call.py
+++ b/fuzzinator/call/stream_monitored_subprocess_call.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -26,7 +26,7 @@ class StreamMonitoredSubprocessCall(Call):
     """
     Subprocess invocation-based call of a SUT that takes test input on its
     command line. The main difference from
-    :func:`fuzzinator.call.SubprocessCall` is that it continuously monitors
+    :class:`fuzzinator.call.SubprocessCall` is that it continuously monitors
     the stdout and stderr streams of the SUT and forces it to terminate if
     some predefined patterns are appearing.
 

--- a/fuzzinator/controller.py
+++ b/fuzzinator/controller.py
@@ -124,7 +124,7 @@ class Controller(object):
           formatted. The class must also contain a method named ``summary``,
           also accepting an ``issue`` keyword argument, which should return a
           summary description (preferably a single line of text). (Optional,
-          default: :func:`fuzzinator.formatter.JsonFormatter`.)
+          default: :class:`fuzzinator.formatter.JsonFormatter`.)
 
           See package :mod:`fuzzinator.formatter` for further potential
           formatters.

--- a/fuzzinator/fuzzer/afl_runner.py
+++ b/fuzzinator/fuzzer/afl_runner.py
@@ -29,7 +29,7 @@ class AFLRunner(Fuzzer):
       - ``afl_fuzz``: path to the AFL fuzzer tool.
       - ``sut_command``: the string to append to the command string used to
         invoke AFL, probably the same string that is used for
-        :func:`fuzzinator.call.SubprocessCall`'s command parameter (the
+        :class:`fuzzinator.call.SubprocessCall`'s command parameter (the
         ``{test}`` substring is automatically replaced with the ``@@`` input
         file placeholder used by AFL).
       - ``input``: the directory of initial test cases for AFL.


### PR DESCRIPTION
Some building blocks were functions in the past, but they had all been converted to classes some time ago. The documentation did not follow this change everywhere, some cross-references kept using the `:func:` role. These have been updated to `:class:` to reflect the current status.