### PR TITLE
Make tests pass again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'  # FIXME: experiencing fatal error (astroid-error) on py3.12.0
       - run: pip install --upgrade tox
       - run: tox -v -e lint
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -29,7 +29,7 @@ disable=
     import-outside-toplevel, consider-using-with, deprecated-module,
     consider-using-dict-items, too-many-boolean-expressions,
     unspecified-encoding, bad-super-call,
-    attribute-defined-outside-init
+    attribute-defined-outside-init, invalid-overridden-method
 
 [TYPECHECK]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ packages = find:
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    chardet<4  # FIXME: <4 is not a direct constraint but required by requests
     chevron
     google-api-python-client
     importlib-metadata; python_version < "3.8"
@@ -43,7 +42,6 @@ install_requires =
     PyGithub
     pymongo
     pyperclip
-    requests<2.25  # FIXME: not a direct dependency, required by PyGithub & requests conflict
     python-bugzilla
     python-gitlab
     rainbow_logging_handler

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ usedevelop = true
 [testenv:lint]
 deps =
     pycodestyle
-    pylint
+    pylint<3  # FIXME: experiencing fatal error (astroid-error) with pylint 3.0.0-3.0.2
 commands =
     pylint fuzzinator
     pycodestyle fuzzinator --ignore=E501,E241


### PR DESCRIPTION
Make install work
- Remove indirect install requirements. The chardet and requests packages were originally added as requirements with constraints because of some conflicts between the PyGithub and requests packages. But now they are causing install issues.

Make pylint pass
- Constrain pylint to v2.x, since v3.0.0-3.0.2 reports fatal error (astroid-error) while checking.
- Pin GH Actions lint job to Python 3.11, since pylint (v2 and v3) reports fatal error (astroid-error) on Python 3.12.
- Disable invalid-overridden-method pylint warning caused by recent urwid versions.