### PR TITLE
List every disabled message on a separate line in .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -17,19 +17,35 @@ extension-pkg-allow-list=fcntl, math, select
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
-    useless-option-value,
-    line-too-long, fixme, missing-docstring, invalid-name, no-self-use, unused-argument,
-    wildcard-import, unused-wildcard-import, ungrouped-imports,
-    too-many-arguments, too-many-locals,
-    too-many-statements, too-many-return-statements, too-many-branches,
-    too-many-instance-attributes, too-few-public-methods,
-    redefined-builtin, broad-except, protected-access,
-    useless-object-inheritance, unnecessary-pass, duplicate-code,
-    abstract-method, arguments-differ, cyclic-import, bad-whitespace,
-    import-outside-toplevel, consider-using-with, deprecated-module,
-    consider-using-dict-items, too-many-boolean-expressions,
-    unspecified-encoding, bad-super-call,
-    attribute-defined-outside-init, invalid-overridden-method
+    abstract-method,
+    arguments-differ,
+    attribute-defined-outside-init,
+    bad-super-call,
+    broad-except,
+    consider-using-with,
+    duplicate-code,
+    fixme,
+    import-outside-toplevel,
+    invalid-name,
+    invalid-overridden-method,
+    line-too-long,
+    missing-docstring,
+    no-self-use,  # disables warning in older pylint
+    protected-access,
+    redefined-builtin,
+    too-few-public-methods,
+    too-many-arguments,
+    too-many-boolean-expressions,
+    too-many-branches,
+    too-many-instance-attributes,
+    too-many-locals,
+    too-many-return-statements,
+    too-many-statements,
+    unnecessary-pass,
+    unspecified-encoding,
+    unused-argument,
+    useless-object-inheritance,
+    useless-option-value,  # disables warning in recent pylint that does not check for no-self-use anymore
 
 [TYPECHECK]
 


### PR DESCRIPTION
This makes tracking changes (diffs) easier. (Should be kept in alphabetic order. Should be reviewed from time to time.)

Also, drop disables that are unnecessary.