### PR TITLE
Avoid setup-java step on GH Actions if possible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
+        if: matrix.os == 'windows-latest'
       - run: pip install --upgrade tox
       - run: tox -v -e py
 


### PR DESCRIPTION
All GH Action runner images have Java pre-installed. Both ubuntu-latest and macos-latest have Java 11+ as default. Only windows-latest has Java 8 as default. So avoid a superfluous setup-java step in all jobs except the tests on windows-latest.