### PR TITLE
Pylint-induced maintenance

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -41,10 +41,8 @@ disable=
     too-many-locals,
     too-many-return-statements,
     too-many-statements,
-    unnecessary-pass,
     unspecified-encoding,
     unused-argument,
-    useless-object-inheritance,
     useless-option-value,  # disables warning in recent pylint that does not check for no-self-use anymore
 
 [TYPECHECK]

--- a/fuzzinator/call/adaptive_timeout_decorator.py
+++ b/fuzzinator/call/adaptive_timeout_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -10,7 +10,7 @@ from math import ceil, sqrt
 from multiprocessing import Value
 
 
-class AdaptiveTimeoutDecorator(object):
+class AdaptiveTimeoutDecorator:
     """
     Decorator for SUT calls used in validate or reduce jobs. It helps
     dynamically optimizing the timeout of SUT calls. It works with SUTs

--- a/fuzzinator/call/call.py
+++ b/fuzzinator/call/call.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,7 +6,7 @@
 # according to those terms.
 
 
-class Call(object):
+class Call:
     """
     Abstract base class to represent how a software-under-test (SUT) can be
     called/executed.

--- a/fuzzinator/call/call_decorator.py
+++ b/fuzzinator/call/call_decorator.py
@@ -8,7 +8,7 @@
 from inspect import signature
 
 
-class CallDecorator(object):
+class CallDecorator:
     """
     Base class for SUT call (i.e., :class:`Call`) decorators.
     """

--- a/fuzzinator/call/regex_automaton.py
+++ b/fuzzinator/call/regex_automaton.py
@@ -8,7 +8,7 @@
 import re
 
 
-class RegexAutomaton(object):
+class RegexAutomaton:
     """
     Auxiliary class to recognize patterns in textual data and process them with
     user-defined automaton-like instructions.

--- a/fuzzinator/controller.py
+++ b/fuzzinator/controller.py
@@ -21,7 +21,7 @@ from .listener import ListenerManager
 from .mongo_driver import MongoDriver
 
 
-class Controller(object):
+class Controller:
     """
     Fuzzinator's main controller that orchestrates a fuzz session by scheduling
     all related activities (e.g., keeps SUTs up-to-date, runs fuzzers and feeds

--- a/fuzzinator/exporter/exporter.py
+++ b/fuzzinator/exporter/exporter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,7 +6,7 @@
 # according to those terms.
 
 
-class Exporter(object):
+class Exporter:
     """
     Abstract base class to represent issue exporters.
     """

--- a/fuzzinator/formatter/formatter.py
+++ b/fuzzinator/formatter/formatter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,7 +6,7 @@
 # according to those terms.
 
 
-class Formatter(object):
+class Formatter:
     """
     Abstract base class to represent issue formatters.
     """

--- a/fuzzinator/formatter/formatter_decorator.py
+++ b/fuzzinator/formatter/formatter_decorator.py
@@ -8,7 +8,7 @@
 from inspect import signature
 
 
-class FormatterDecorator(object):
+class FormatterDecorator:
     """
     Base class for :class:`Formatter` decorators.
     """

--- a/fuzzinator/fuzzer/fuzzer.py
+++ b/fuzzinator/fuzzer/fuzzer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,7 +6,7 @@
 # according to those terms.
 
 
-class Fuzzer(object):
+class Fuzzer:
     """
     Abstract base class to represent a (random) test case generator, a.k.a.
     fuzzer.

--- a/fuzzinator/fuzzer/fuzzer_decorator.py
+++ b/fuzzinator/fuzzer/fuzzer_decorator.py
@@ -8,7 +8,7 @@
 from inspect import signature
 
 
-class FuzzerDecorator(object):
+class FuzzerDecorator:
     """
     Base class for :class:`Fuzzer` decorators.
     """

--- a/fuzzinator/job/call_job.py
+++ b/fuzzinator/job/call_job.py
@@ -8,7 +8,7 @@
 import hashlib
 
 
-class CallJob(object):
+class CallJob:
     """
     Base class for jobs that call SUTs and can find new issues.
     """

--- a/fuzzinator/job/update_job.py
+++ b/fuzzinator/job/update_job.py
@@ -8,7 +8,7 @@
 from ..config import config_get_object
 
 
-class UpdateJob(object):
+class UpdateJob:
     """
     Class for running SUT update jobs.
     """

--- a/fuzzinator/listener/event_listener.py
+++ b/fuzzinator/listener/event_listener.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,7 +6,7 @@
 # according to those terms.
 
 
-class EventListener(object):
+class EventListener:
     """
     A no-op base class for listeners that can get notified by
     :class:`fuzzinator.Controller` on various events of a fuzz sessions.
@@ -29,7 +29,6 @@ class EventListener(object):
 
         :param int load: number between 0 and controller's capacity.
         """
-        pass
 
     def on_fuzz_job_added(self, job_id, cost, sut, fuzzer, batch):
         """
@@ -45,7 +44,6 @@ class EventListener(object):
             requested from the fuzzer (may be ``inf``).
         :type batch: int, float
         """
-        pass
 
     def on_reduce_job_added(self, job_id, cost, sut, issue_oid, issue_id, size):
         """
@@ -60,7 +58,6 @@ class EventListener(object):
         :param int size: size of the test case associated with the issue to be
             reduced.
         """
-        pass
 
     def on_update_job_added(self, job_id, cost, sut):
         """
@@ -71,7 +68,6 @@ class EventListener(object):
         :param str sut: short name of the SUT to be updated (name of the
             corresponding config section without the "sut." prefix).
         """
-        pass
 
     def on_validate_job_added(self, job_id, cost, sut, issue_oid, issue_id):
         """
@@ -84,7 +80,6 @@ class EventListener(object):
         :param str issue_oid: ``'_id'`` property of the issue to be validated.
         :param Any issue_id: ``'id'`` property of the issue to be validated.
         """
-        pass
 
     def on_job_activated(self, job_id):
         """
@@ -92,7 +87,6 @@ class EventListener(object):
 
         :param int job_id: unique identifier of the activated job.
         """
-        pass
 
     def on_job_progressed(self, job_id, progress):
         """
@@ -104,7 +98,6 @@ class EventListener(object):
             reduce jobs, this is the current size of the test case being reduced
             (number between the original test size and 0).
         """
-        pass
 
     def on_job_removed(self, job_id):
         """
@@ -112,7 +105,6 @@ class EventListener(object):
 
         :param int job_id: unique identifier of the finished job.
         """
-        pass
 
     def on_issue_added(self, job_id, issue):
         """
@@ -124,7 +116,6 @@ class EventListener(object):
             the issue, the fuzzer that generated the test case, the ID of the
             issue - is stored in appropriate properties of the issue).
         """
-        pass
 
     def on_issue_invalidated(self, job_id, issue):
         """
@@ -135,7 +126,6 @@ class EventListener(object):
             (listener is free to decide how to react, an option is to remove the
             issue from the database).
         """
-        pass
 
     def on_issue_updated(self, job_id, issue):
         """
@@ -144,7 +134,6 @@ class EventListener(object):
         :param int job_id: identifier of the job that has updated the issue.
         :param dict issue: the issue object that has changed.
         """
-        pass
 
     def on_issue_reduced(self, job_id, issue):
         """
@@ -153,7 +142,6 @@ class EventListener(object):
         :param int job_id: identifier of the job that has reduced the issue.
         :param dict issue: the issue object that got reduced.
         """
-        pass
 
     def warning(self, job_id, msg):
         """
@@ -164,7 +152,6 @@ class EventListener(object):
             the core).
         :param str msg: description of the problem.
         """
-        pass
 
     def on_stats_updated(self):
         """
@@ -172,4 +159,3 @@ class EventListener(object):
         counts, issue counts, unique issue counts) are updated in the
         framework's database.
         """
-        pass

--- a/fuzzinator/listener/listener_manager.py
+++ b/fuzzinator/listener/listener_manager.py
@@ -13,7 +13,7 @@ from .event_listener import EventListener
 logger = logging.getLogger(__name__)
 
 
-class Trampoline(object):
+class Trampoline:
 
     def __init__(self, manager, name):
         self.manager = manager
@@ -27,7 +27,7 @@ class Trampoline(object):
                 logger.warning('Unhandled exception in listener %r.', self.name, exc_info=e)
 
 
-class ListenerManager(object):
+class ListenerManager:
     """
     Class that registers listeners to various events and executes all of them
     when the event has triggered.

--- a/fuzzinator/mongo_driver.py
+++ b/fuzzinator/mongo_driver.py
@@ -16,7 +16,7 @@ from pymongo import ASCENDING, MongoClient, ReturnDocument
 logger = logging.getLogger(__name__)
 
 
-class MongoDriver(object):
+class MongoDriver:
 
     def __init__(self, uri, server_selection_timeout):
         self.uri = uri

--- a/fuzzinator/reduce/picire_common.py
+++ b/fuzzinator/reduce/picire_common.py
@@ -17,7 +17,7 @@ from ..config import as_bool, as_int_or_inf
 from .reducer import Reducer
 
 
-class PicireTester(object):
+class PicireTester:
 
     def __init__(self, *, test_builder, sut_call, issue, on_job_progressed, filename, encoding, new_issues):
         self._test_builder = test_builder

--- a/fuzzinator/reduce/reducer.py
+++ b/fuzzinator/reduce/reducer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,7 +6,7 @@
 # according to those terms.
 
 
-class Reducer(object):
+class Reducer:
     """
     Abstract base class to represent test case reducers.
     """

--- a/fuzzinator/tracker/tracker.py
+++ b/fuzzinator/tracker/tracker.py
@@ -111,4 +111,3 @@ class TrackerError(Exception):
     """
     Raised when a :class:`Tracker` operation cannot be performed.
     """
-    pass

--- a/fuzzinator/ui/tui/reporter_dialogs.py
+++ b/fuzzinator/ui/tui/reporter_dialogs.py
@@ -104,7 +104,6 @@ class ReportDialog(PopUpTarget):
             collect input from the user, usually based on ``settings`` (empty by
             default).
         """
-        pass
 
     def set_duplicate(self, btn, state):
         if state:

--- a/fuzzinator/ui/tui/table.py
+++ b/fuzzinator/ui/tui/table.py
@@ -148,7 +148,7 @@ class ScrollingListBox(WidgetWrap):
         return None
 
 
-class TableColumn(object):
+class TableColumn:
     align = 'left'
     wrap = 'space'
     padding = None

--- a/fuzzinator/ui/tui/tui.py
+++ b/fuzzinator/ui/tui/tui.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -24,7 +24,7 @@ from .widgets import MainWindow
 logger = logging.getLogger(__name__)
 
 
-class Tui(object):
+class Tui:
     signals = ['close']
 
     def __init__(self, controller, style):

--- a/fuzzinator/ui/tui/tui_listener.py
+++ b/fuzzinator/ui/tui/tui_listener.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -11,13 +11,13 @@ import os
 from ...listener import EventListener
 
 
-class TuiListener(object):
+class TuiListener:
 
     def __init__(self, pipe, events, lock):
         for fn, _ in inspect.getmembers(EventListener, predicate=inspect.isfunction):
             setattr(self, fn, self.Trampoline(name=fn, pipe=pipe, events=events, lock=lock))
 
-    class Trampoline(object):
+    class Trampoline:
         def __init__(self, name, pipe, events, lock):
             self.name = name
             self.pipe = pipe

--- a/fuzzinator/ui/wui/wui.py
+++ b/fuzzinator/ui/wui/wui.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 root_logger = logging.getLogger()
 
 
-class Wui(object):
+class Wui:
 
     def __init__(self, controller, port, address, cert, key, debug):
         self.events = Queue()

--- a/fuzzinator/ui/wui/wui_listener.py
+++ b/fuzzinator/ui/wui/wui_listener.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2019 Tamas Keri.
-# Copyright (c) 2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2019-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -11,7 +11,7 @@ import inspect
 from ...listener import EventListener
 
 
-class Trampoline(object):
+class Trampoline:
 
     def __init__(self, name, events, lock):
         self.name = name
@@ -26,7 +26,7 @@ class Trampoline(object):
                 pass
 
 
-class WuiListener(object):
+class WuiListener:
 
     def __init__(self, events, lock):
         for fn, _ in inspect.getmembers(EventListener, predicate=inspect.isfunction):

--- a/fuzzinator/update/update.py
+++ b/fuzzinator/update/update.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,7 +6,7 @@
 # according to those terms.
 
 
-class Update(object):
+class Update:
     """
     Abstract base class to represent how a software-under-test (SUT) can be
     updated.

--- a/fuzzinator/update/update_condition.py
+++ b/fuzzinator/update/update_condition.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,7 +6,7 @@
 # according to those terms.
 
 
-class UpdateCondition(object):
+class UpdateCondition:
     """
     Abstract base class to represent how to determine whether a
     software-under-test (SUT) should be updated.


### PR DESCRIPTION
- Remove the explicit `object` superclass definition from classes. In Python3, object is the implicit superclass. There is no need to explicitly define it.
- Remove unnecessary pass.