### PR TITLE
Ensure test quality via linting

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+#
+# Licensed under the BSD 3-Clause License
+# <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+# This file may not be copied, modified, or distributed except
+# according to those terms.
+
+# INTENTIONALLY EMPTY

--- a/tests/call/__init__.py
+++ b/tests/call/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+#
+# Licensed under the BSD 3-Clause License
+# <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+# This file may not be copied, modified, or distributed except
+# according to those terms.
+
+# INTENTIONALLY EMPTY

--- a/tests/call/test_anonymize_decorator.py
+++ b/tests/call/test_anonymize_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -9,7 +9,7 @@ import pytest
 
 import fuzzinator
 
-from common_call import MockAlwaysFailCall, MockNeverFailCall
+from .common_call import MockAlwaysFailCall, MockNeverFailCall
 
 
 @pytest.mark.parametrize('call_init_kwargs, call_kwargs', [

--- a/tests/call/test_exit_code_filter.py
+++ b/tests/call/test_exit_code_filter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -9,7 +9,7 @@ import pytest
 
 import fuzzinator
 
-from common_call import MockAlwaysFailCall, MockNeverFailCall
+from .common_call import MockAlwaysFailCall, MockNeverFailCall
 
 
 @pytest.mark.parametrize('call_init_kwargs, call_kwargs', [

--- a/tests/call/test_file_reader_decorator.py
+++ b/tests/call/test_file_reader_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,12 +6,13 @@
 # according to those terms.
 
 import os
-import pytest
 import shutil
+
+import pytest
 
 import fuzzinator
 
-from common_call import blinesep, resources_dir, MockAlwaysFailCall, MockNeverFailCall
+from .common_call import blinesep, resources_dir, MockAlwaysFailCall, MockNeverFailCall
 
 
 @pytest.mark.parametrize('dec_kwargs', [

--- a/tests/call/test_file_writer_decorator.py
+++ b/tests/call/test_file_writer_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,12 +6,13 @@
 # according to those terms.
 
 import os
-import pytest
 import re
+
+import pytest
 
 import fuzzinator
 
-from common_call import MockAlwaysFailCall, MockNeverFailCall
+from .common_call import MockAlwaysFailCall, MockNeverFailCall
 
 
 @pytest.mark.parametrize('call_init_kwargs, call_kwargs', [

--- a/tests/call/test_platform_info_decorator.py
+++ b/tests/call/test_platform_info_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -9,7 +9,7 @@ import pytest
 
 import fuzzinator
 
-from common_call import MockAlwaysFailCall, MockNeverFailCall
+from .common_call import MockAlwaysFailCall, MockNeverFailCall
 
 
 @pytest.mark.parametrize('call_init_kwargs, call_kwargs', [

--- a/tests/call/test_regex_filter.py
+++ b/tests/call/test_regex_filter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -9,7 +9,7 @@ import pytest
 
 import fuzzinator
 
-from common_call import MockAlwaysFailCall, MockNeverFailCall
+from .common_call import MockAlwaysFailCall, MockNeverFailCall
 
 
 @pytest.mark.parametrize('call_init_kwargs, call_kwargs', [

--- a/tests/call/test_sanitizer_analyzer_decorator.py
+++ b/tests/call/test_sanitizer_analyzer_decorator.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Tamas Keri
-# Copyright (c) 2020-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2020-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -7,11 +7,12 @@
 # according to those terms.
 
 import os
+
 import pytest
 
 import fuzzinator
 
-from common_call import resources_dir, MockAlwaysFailCall
+from .common_call import resources_dir, MockAlwaysFailCall
 
 
 @pytest.mark.parametrize('call_class, call_kwargs, exp', [

--- a/tests/call/test_stdin_subprocess_call.py
+++ b/tests/call/test_stdin_subprocess_call.py
@@ -6,12 +6,13 @@
 # according to those terms.
 
 import os
-import pytest
 import sys
+
+import pytest
 
 import fuzzinator
 
-from common_call import linesep, resources_dir
+from .common_call import linesep, resources_dir
 
 
 @pytest.mark.parametrize('command, cwd, env, no_exit_code, test, exp', [
@@ -21,7 +22,7 @@ from common_call import linesep, resources_dir
     (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --echo-stdin --exit-code 1', resources_dir, None, None, b'foo', {'stdout': 'foo', 'stderr': '', 'exit_code': 1}),
     (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --print-env BAR --echo-stdin --exit-code 1', resources_dir, '{"BAR": "baz"}', None, b'foo', {'stdout': f'baz{linesep}foo', 'stderr': '', 'exit_code': 1}),
     (f'{sys.executable} {os.path.join(resources_dir, "mock_tool.py")} --echo-stdin --exit-code 0', None, None, 'True', b'foo', {'stdout': 'foo', 'stderr': '', 'exit_code': 0}),
-    ])
+])
 def test_stdin_subprocess_call(command, cwd, env, no_exit_code, test, exp):
     call = fuzzinator.call.StdinSubprocessCall(command=command, cwd=cwd, env=env, no_exit_code=no_exit_code)
     with call:

--- a/tests/call/test_stream_monitored_subprocess_call.py
+++ b/tests/call/test_stream_monitored_subprocess_call.py
@@ -6,12 +6,13 @@
 # according to those terms.
 
 import os
-import pytest
 import sys
+
+import pytest
 
 import fuzzinator
 
-from common_call import linesep, resources_dir
+from .common_call import linesep, resources_dir
 
 
 @pytest.mark.skipif(not hasattr(fuzzinator.call, 'StreamMonitoredSubprocessCall'),

--- a/tests/call/test_subprocess_call.py
+++ b/tests/call/test_subprocess_call.py
@@ -6,12 +6,13 @@
 # according to those terms.
 
 import os
-import pytest
 import sys
+
+import pytest
 
 import fuzzinator
 
-from common_call import linesep, resources_dir
+from .common_call import linesep, resources_dir
 
 
 @pytest.mark.parametrize('command, cwd, env, no_exit_code, test, exp', [

--- a/tests/call/test_subprocess_property_decorator.py
+++ b/tests/call/test_subprocess_property_decorator.py
@@ -6,12 +6,13 @@
 # according to those terms.
 
 import os
-import pytest
 import sys
+
+import pytest
 
 import fuzzinator
 
-from common_call import linesep, resources_dir, MockAlwaysFailCall, MockNeverFailCall
+from .common_call import linesep, resources_dir, MockAlwaysFailCall, MockNeverFailCall
 
 
 @pytest.mark.parametrize('call_init_kwargs, call_kwargs', [

--- a/tests/call/test_unique_decorator.py
+++ b/tests/call/test_unique_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -9,7 +9,7 @@ import pytest
 
 import fuzzinator
 
-from common_call import MockAlwaysFailCall, MockNeverFailCall
+from .common_call import MockAlwaysFailCall, MockNeverFailCall
 
 
 @pytest.mark.parametrize('call_init_kwargs, call_kwargs', [

--- a/tests/exporter/__init__.py
+++ b/tests/exporter/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+#
+# Licensed under the BSD 3-Clause License
+# <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+# This file may not be copied, modified, or distributed except
+# according to those terms.
+
+# INTENTIONALLY EMPTY

--- a/tests/formatter/__init__.py
+++ b/tests/formatter/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+#
+# Licensed under the BSD 3-Clause License
+# <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+# This file may not be copied, modified, or distributed except
+# according to those terms.
+
+# INTENTIONALLY EMPTY

--- a/tests/formatter/test_chevron_formatter.py
+++ b/tests/formatter/test_chevron_formatter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2018-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,11 +6,12 @@
 # according to those terms.
 
 import os
+
 import pytest
 
 import fuzzinator
 
-from common_formatter import mock_issue, mock_templates_dir
+from .common_formatter import mock_issue, mock_templates_dir
 
 
 @pytest.mark.parametrize('issue, formatter_init_kwargs, exp_short, exp_long', [

--- a/tests/formatter/test_jinja_formatter.py
+++ b/tests/formatter/test_jinja_formatter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2018-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,11 +6,12 @@
 # according to those terms.
 
 import os
+
 import pytest
 
 import fuzzinator
 
-from common_formatter import mock_issue, mock_templates_dir
+from .common_formatter import mock_issue, mock_templates_dir
 
 
 @pytest.mark.parametrize('issue, formatter_init_kwargs, exp_short, exp_long', [

--- a/tests/formatter/test_markdown_decorator.py
+++ b/tests/formatter/test_markdown_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2018-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -9,7 +9,7 @@ import pytest
 
 import fuzzinator
 
-from common_formatter import MockFixedFormatter, MockIdFormatter
+from .common_formatter import MockFixedFormatter, MockIdFormatter
 
 
 @pytest.mark.parametrize('issue, formatter_class, formatter_init_kwargs, exp_short, exp_long', [

--- a/tests/formatter/test_string_formatter.py
+++ b/tests/formatter/test_string_formatter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2018-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,11 +6,12 @@
 # according to those terms.
 
 import os
+
 import pytest
 
 import fuzzinator
 
-from common_formatter import mock_issue, mock_templates_dir
+from .common_formatter import mock_issue, mock_templates_dir
 
 
 @pytest.mark.parametrize('issue, formatter_init_kwargs, exp_short, exp_long', [

--- a/tests/fuzzer/__init__.py
+++ b/tests/fuzzer/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+#
+# Licensed under the BSD 3-Clause License
+# <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+# This file may not be copied, modified, or distributed except
+# according to those terms.
+
+# INTENTIONALLY EMPTY

--- a/tests/fuzzer/test_byte_flip_decorator.py
+++ b/tests/fuzzer/test_byte_flip_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -9,7 +9,7 @@ import pytest
 
 import fuzzinator
 
-from common_fuzzer import MockExhaustedFuzzer, MockRepeatingFuzzer
+from .common_fuzzer import MockExhaustedFuzzer, MockRepeatingFuzzer
 
 
 @pytest.mark.parametrize('fuzzer_class, fuzzer_init_kwargs, dec_kwargs, exp_flip_cnt', [

--- a/tests/fuzzer/test_fuzzer_file_writer_decorator.py
+++ b/tests/fuzzer/test_fuzzer_file_writer_decorator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,12 +6,13 @@
 # according to those terms.
 
 import os
-import pytest
 import re
+
+import pytest
 
 import fuzzinator
 
-from common_fuzzer import MockExhaustedFuzzer, MockRepeatingFuzzer
+from .common_fuzzer import MockExhaustedFuzzer, MockRepeatingFuzzer
 
 
 @pytest.mark.parametrize('fuzzer_class, fuzzer_init_kwargs, dec_kwargs, exp', [

--- a/tests/fuzzer/test_list_directory.py
+++ b/tests/fuzzer/test_list_directory.py
@@ -1,17 +1,17 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import pytest
-
 from os.path import join
+
+import pytest
 
 import fuzzinator
 
-from common_fuzzer import blinesep, resources_dir
+from .common_fuzzer import blinesep, resources_dir
 
 mock_tests = join(resources_dir, 'mock_tests')
 

--- a/tests/fuzzer/test_subprocess_runner.py
+++ b/tests/fuzzer/test_subprocess_runner.py
@@ -5,14 +5,15 @@
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import pytest
 import sys
 
 from os.path import join
 
+import pytest
+
 import fuzzinator
 
-from common_fuzzer import blinesep, resources_dir
+from .common_fuzzer import blinesep, resources_dir
 
 
 @pytest.mark.parametrize('command, cwd, env, contents, exp', [

--- a/tests/reduce/__init__.py
+++ b/tests/reduce/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+#
+# Licensed under the BSD 3-Clause License
+# <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+# This file may not be copied, modified, or distributed except
+# according to those terms.
+
+# INTENTIONALLY EMPTY

--- a/tests/reduce/test_picire.py
+++ b/tests/reduce/test_picire.py
@@ -1,17 +1,17 @@
-# Copyright (c) 2018-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2018-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import pytest
-
 from functools import partial
+
+import pytest
 
 import fuzzinator
 
-from common_reduce import MockFailIfContainsCall
+from .common_reduce import MockFailIfContainsCall
 
 
 @pytest.mark.parametrize('call, call_init_kwargs, issue, exp_test, exp_issues', [

--- a/tests/reduce/test_picireny.py
+++ b/tests/reduce/test_picireny.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2018-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -7,13 +7,14 @@
 
 import json
 import os
-import pytest
 
 from functools import partial
 
+import pytest
+
 import fuzzinator
 
-from common_reduce import MockFailIfContainsCall, mock_grammars_dir
+from .common_reduce import MockFailIfContainsCall, mock_grammars_dir
 
 
 @pytest.mark.parametrize('format, grammar, start, replacements', [

--- a/tests/update/__init__.py
+++ b/tests/update/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+#
+# Licensed under the BSD 3-Clause License
+# <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+# This file may not be copied, modified, or distributed except
+# according to those terms.
+
+# INTENTIONALLY EMPTY

--- a/tests/update/test_subprocess_update.py
+++ b/tests/update/test_subprocess_update.py
@@ -6,12 +6,13 @@
 # according to those terms.
 
 import os
-import pytest
 import sys
+
+import pytest
 
 import fuzzinator
 
-from common_update import resources_dir
+from .common_update import resources_dir
 
 
 @pytest.mark.parametrize('command, cwd, env', [

--- a/tests/update/test_timestamp_update_condition.py
+++ b/tests/update/test_timestamp_update_condition.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,6 +6,7 @@
 # according to those terms.
 
 import os
+
 import pytest
 
 import fuzzinator
@@ -13,10 +14,10 @@ import fuzzinator
 
 @pytest.mark.parametrize('touch, age, exp', [
     (None, '0:0:1', True),
-    (-60*60*24*31, '0:0:10', True),
-    (-60*60*24*31, '0:10:0', True),
-    (-60*60*24*31, '10:0:0', True),
-    (-60*60*24*31, '1:0:0:0', True),
+    (-60 * 60 * 24 * 31, '0:0:10', True),
+    (-60 * 60 * 24 * 31, '0:10:0', True),
+    (-60 * 60 * 24 * 31, '10:0:0', True),
+    (-60 * 60 * 24 * 31, '1:0:0:0', True),
     (0, '0:0:10', False),
     (0, '0:10:0', False),
     (0, '10:0:0', False),

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,10 @@ usedevelop = true
 deps =
     pycodestyle
     pylint<3  # FIXME: experiencing fatal error (astroid-error) with pylint 3.0.0-3.0.2
+    pytest
 commands =
-    pylint src/fuzzinator
-    pycodestyle src/fuzzinator --ignore=E501,E241
+    pylint src/fuzzinator tests
+    pycodestyle src/fuzzinator tests --ignore=E501,E241
 
 [testenv:eslint]
 deps =


### PR DESCRIPTION
- Change test folders to packages to allow relative imports
- List standard modules first in imports
- Avoid unnecessary indenting of brackets
- Use whitespace around binary operators