### PR TITLE
Correctly add package data directories to distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
 [options]
 package_dir =
     = src
-packages = find:
+packages = find_namespace:
 include_package_data = True
 python_requires = >=3.8
 install_requires =


### PR DESCRIPTION
Python recognizes package data directories as importable packages. However, as they are absent from setuptools' `packages` configuration, this causes warnings that they would be ignored. The recommended approach is to treat data as namespace package using the `find_namespace:` discovery mechanism.

The affected data directories / packages:
- fuzzinator.ui.tui.resources
- fuzzinator.ui.wui.resources.static
- fuzzinator.ui.wui.resources.static.assets
- fuzzinator.ui.wui.resources.static.images
- fuzzinator.ui.wui.resources.static.scripts
- fuzzinator.ui.wui.resources.static.styles
- fuzzinator.ui.wui.resources.templates
- fuzzinator.ui.wui.resources.templates.report