### PR TITLE
General project maintenance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', 'pypy-3.11']
         exclude:
           # NOTE: pynacl should not be built from sdist, but it has no binary
           # wheel available for windows+pypy
           - os: windows-latest
-            python-version: 'pypy-3.10'
+            python-version: 'pypy-3.11'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ interfaces:
 Requirements
 ============
 
-* Python_ >= 3.8
+* Python_ >= 3.9
 * MongoDB_ >= 3.6 (either local installation or access to remote database)
 * Java_ SE >= 7 JRE or JDK (optional, required if the *Picireny* test case
   reducer is used)

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,15 +6,13 @@ long_description_content_type = text/x-rst
 author = Renata Hodovan, Akos Kiss
 author_email = hodovan@inf.u-szeged.hu, akiss@inf.u-szeged.hu
 url = https://github.com/renatahodovan/fuzzinator
-license = BSD
+license_expression = BSD-3-Clause
 license_files = LICENSE.rst
 classifiers =
     Intended Audience :: Developers
-    License :: OSI Approved :: BSD License
     # Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -27,7 +25,7 @@ package_dir =
     = src
 packages = find_namespace:
 include_package_data = True
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
     chevron
     google-api-python-client
@@ -48,7 +46,7 @@ install_requires =
     python-gitlab
     rainbow_logging_handler
     tornado
-    urwid
+    urwid<3.0.0
     xson
 
 [options.packages.find]


### PR DESCRIPTION
- Remove support of Python 3.8: Python 3.8 reached its end of life in October 2024, hence we do not support it either
- Bump PyPy to 3.11 on GH Actions
- Use SPDX short-form license identifier to describe license: The license core metadata field has been deprecated and was replaced by the SPDX-based license-expression field.
- Constrain Urwid to <3.0.0: Urwid 3.0.0 dropped BoxWidget, which TUI is relying on.