### PR TITLE
Use furo style for docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,22 +65,12 @@ add_function_parentheses = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = 'furo'
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.
 #
-html_title = '%s %s documentation' % (project, release)
-
-# A shorter title for the navigation bar.  Default is the same as html_title.
-#
-html_short_title = '%s %s documentation' % (project, version)
+html_title = project
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
+furo
 sphinx>=5.2
-sphinx_rtd_theme
 sphinxcontrib-runcmd

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,8 @@ commands =
 
 [testenv:docs]
 deps = -rdocs/requirements.txt
-commands = sphinx-build docs {envtmpdir} -E
+changedir = docs
+commands = sphinx-build . {envtmpdir} -E -n
 
 [testenv:build]
 deps =


### PR DESCRIPTION
Also:
- Build documentation in nit-picky mode
- Run sphinx-build from the docs directory when toxing
- Bump ReadTheDocs build.os to ubuntu-24.04