### PR TITLE
Update Python support: drop 3.9, add 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', 'pypy-3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.11']
         exclude:
           # NOTE: pynacl should not be built from sdist, but it has no binary
           # wheel available for windows+pypy

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ interfaces:
 Requirements
 ============
 
-* Python_ >= 3.9
+* Python_ >= 3.10
 * MongoDB_ >= 3.6 (either local installation or access to remote database)
 * Java_ SE >= 7 JRE or JDK (optional, required if the *Picireny* test case
   reducer is used)

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,11 +13,11 @@ classifiers =
     # Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Software Development :: Testing
 
 [options]
@@ -25,7 +25,7 @@ package_dir =
     = src
 packages = find_namespace:
 include_package_data = True
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     chevron
     google-api-python-client


### PR DESCRIPTION
Python 3.14 has been released, while 3.9 reached its end of life.